### PR TITLE
Small bug fixes 

### DIFF
--- a/src/components/ListItem.js
+++ b/src/components/ListItem.js
@@ -2,8 +2,8 @@ import React, { Component } from 'react';
 import List from './List';
 import { connect } from 'react-redux';
 import * as smActions from '../actions/sm-data';
-import * as peaksActions from '../actions/peaks-instance';
-import * as forms from '../actions/forms';
+import { deleteSegment } from '../actions/peaks-instance';
+import { handleEditingTimespans } from '../actions/forms';
 import PropTypes from 'prop-types';
 import { ItemTypes } from '../services/Constants';
 import { DragSource, DropTarget } from 'react-dnd';
@@ -60,6 +60,12 @@ class ListItem extends Component {
 
   handleDelete = () => {
     const { item } = this.props;
+
+    // Remove DnD source & targets if the current item was active
+    if (this.props.item.active) {
+      this.handleShowDropTargetsClick();
+    }
+
     this.props.deleteItem(item.id);
     this.props.deleteSegment(item);
   };
@@ -67,6 +73,11 @@ class ListItem extends Component {
   handleEditClick = () => {
     // Disable the edit buttons of other list items
     this.props.handleEditingTimespans(0);
+
+    // Remove DnD source & targets if the current item was active
+    if (this.props.item.active) {
+      this.handleShowDropTargetsClick();
+    }
 
     this.setState({ editing: true });
   };
@@ -168,8 +179,8 @@ const mapDispatchToProps = {
   removeDropTargets: smActions.removeDropTargets,
   removeActiveDragSources: smActions.removeActiveDragSources,
   setActiveDragSource: smActions.setActiveDragSource,
-  deleteSegment: peaksActions.deleteSegment,
-  handleEditingTimespans: forms.handleEditingTimespans
+  deleteSegment: deleteSegment,
+  handleEditingTimespans: handleEditingTimespans
 };
 
 const mapStateToProps = state => ({

--- a/src/containers/WaveformContainer.js
+++ b/src/containers/WaveformContainer.js
@@ -2,7 +2,7 @@ import React, { Component } from 'react';
 import APIUtils from '../api/Utils';
 import { connect } from 'react-redux';
 import { initializeSMDataPeaks } from '../actions/peaks-instance';
-import * as actions from '../actions/forms';
+import { handleEditingTimespans } from '../actions/forms';
 import Waveform from '../components/Waveform';
 import AlertContainer from '../containers/AlertContainer';
 import { configureAlert } from '../services/alert-status';
@@ -74,6 +74,7 @@ class WaveformContainer extends Component {
     } catch (error) {
       isError = true;
       this.handleError(error);
+      this.props.handleEditingTimespans(0);
       // Fetch structure.json when waveform.json is
       this.props.fetchDataAndBuildPeaks(
         baseURL,
@@ -130,7 +131,8 @@ const mapStateToProps = state => ({
 
 const mapDispatchToProps = {
   fetchDataAndBuildPeaks: initializeSMDataPeaks,
-  retrieveWaveformSuccess: retrieveWaveformSuccess
+  retrieveWaveformSuccess: retrieveWaveformSuccess,
+  handleEditingTimespans: handleEditingTimespans
 };
 
 export default connect(


### PR DESCRIPTION
This PR fixes 2 bugs;
1. If a user edits a timespan while DnD is enabled for that particular timespan, the inline edit form is displayed while the DnD is enabled. Even though this doesn't break the application (I couldn't find a way to break it, but maybe possible),  it doesn't look good. @adamjarling If you think this should stay as the way it is, we can revert this :+1: 

2. If a user deletes a timespan while DnD is enabled for that timespan, that particular item gets deleted. But the drop-zones are not removed.

3. When `waveform.json` is not fetched and a warning is emitted, the structure remains editable. If a user clicks on an edit icon for a timespan the app breaks since that action is bound to the Peaks instance, which is created upon successful retrieval of the `waveform.json`.