### PR TITLE
Disable other editing actions when DnD is turned on for an item

### DIFF
--- a/dist/components/ButtonSection.js
+++ b/dist/components/ButtonSection.js
@@ -90,7 +90,7 @@ function (_Component) {
       }); // Clear the redux-store flag when closing the alert from AlertContainer
 
 
-      _this.props.handleEditingTimespans(1);
+      _this.props.handleEditingTimespans(0);
     });
     (0, _defineProperty2["default"])((0, _assertThisInitialized2["default"])(_this), "handleCancelHeadingClick", function () {
       _this.setState({
@@ -100,7 +100,7 @@ function (_Component) {
       _this.clearAlert();
     });
     (0, _defineProperty2["default"])((0, _assertThisInitialized2["default"])(_this), "handleHeadingClick", function () {
-      _this.props.handleEditingTimespans(0); // When opening heading form, delete if a temporary segment exists
+      _this.props.handleEditingTimespans(1); // When opening heading form, delete if a temporary segment exists
 
 
       _this.deleteTempSegment();
@@ -126,7 +126,7 @@ function (_Component) {
       _this.clearAlert(); // Disable editing other items in structure
 
 
-      _this.props.handleEditingTimespans(0); // Create a temporary segment if timespan form is closed
+      _this.props.handleEditingTimespans(1); // Create a temporary segment if timespan form is closed
 
 
       if (!_this.state.timespanOpen) {

--- a/dist/components/ListItem.js
+++ b/dist/components/ListItem.js
@@ -100,11 +100,7 @@ function (_Component) {
       editing: false
     });
     (0, _defineProperty2["default"])((0, _assertThisInitialized2["default"])(_this), "handleDelete", function () {
-      var item = _this.props.item; // Remove DnD source & targets if the current item was active
-
-      if (_this.props.item.active) {
-        _this.handleShowDropTargetsClick();
-      }
+      var item = _this.props.item;
 
       _this.props.deleteItem(item.id);
 
@@ -112,12 +108,7 @@ function (_Component) {
     });
     (0, _defineProperty2["default"])((0, _assertThisInitialized2["default"])(_this), "handleEditClick", function () {
       // Disable the edit buttons of other list items
-      _this.props.handleEditingTimespans(0); // Remove DnD source & targets if the current item was active
-
-
-      if (_this.props.item.active) {
-        _this.handleShowDropTargetsClick();
-      }
+      _this.props.handleEditingTimespans(1);
 
       _this.setState({
         editing: true
@@ -129,7 +120,7 @@ function (_Component) {
       }); // Enable the edit buttons of other list items
 
 
-      _this.props.handleEditingTimespans(1);
+      _this.props.handleEditingTimespans(0);
     });
     (0, _defineProperty2["default"])((0, _assertThisInitialized2["default"])(_this), "handleShowDropTargetsClick", function () {
       var _this$props = _this.props,
@@ -137,13 +128,19 @@ function (_Component) {
           item = _this$props.item,
           removeActiveDragSources = _this$props.removeActiveDragSources,
           removeDropTargets = _this$props.removeDropTargets,
-          setActiveDragSource = _this$props.setActiveDragSource; // Clear out any current drop targets
+          setActiveDragSource = _this$props.setActiveDragSource; // Disable other editing actions
+
+      _this.props.handleEditingTimespans(1); // Clear out any current drop targets
+
 
       removeDropTargets(); // Handle closing of current drag source drop targets, and exit with a clean UI.
 
       if (item.active === true) {
         // Clear out any active drag sources
-        removeActiveDragSources();
+        removeActiveDragSources(); // Enable other editing actions
+
+        _this.props.handleEditingTimespans(0);
+
         return;
       } // Clear out any active drag sources
 
@@ -176,7 +173,8 @@ function (_Component) {
       var itemProp = {
         childrenCount: item.items ? item.items.length : 0,
         label: item.label,
-        type: item.type
+        type: item.type,
+        active: item.active
       };
       return connectDragSource(connectDropTarget(_react["default"].createElement("li", {
         className: active ? 'active' : ''
@@ -223,7 +221,8 @@ var mapDispatchToProps = {
 
 var mapStateToProps = function mapStateToProps(state) {
   return {
-    smData: state.smData
+    smData: state.smData,
+    peaksInstance: state.peaksInstance.peaks
   };
 };
 

--- a/dist/components/ListItemControls.js
+++ b/dist/components/ListItemControls.js
@@ -90,7 +90,7 @@ function (_Component) {
 
       deleteMessage += "?"; // Disable editing of other list items
 
-      _this.props.handleEditingTimespans(0);
+      _this.props.handleEditingTimespans(1);
 
       _this.setState({
         deleteMessage: deleteMessage,
@@ -112,7 +112,7 @@ function (_Component) {
     key: "enableEditing",
     value: function enableEditing() {
       // Enable editing of other list items
-      this.props.handleEditingTimespans(1);
+      this.props.handleEditingTimespans(0);
     }
   }, {
     key: "render",
@@ -129,7 +129,7 @@ function (_Component) {
         className: "edit-controls-wrapper"
       }, item.type === 'span' && _react["default"].createElement(_reactBootstrap.Button, {
         bsStyle: "link",
-        disabled: forms.editingDisabled,
+        disabled: forms.editingDisabled && !item.active,
         onClick: handleShowDropTargetsClick
       }, _react["default"].createElement(_reactFontawesome.FontAwesomeIcon, {
         icon: "dot-circle"

--- a/dist/containers/WaveformContainer.js
+++ b/dist/containers/WaveformContainer.js
@@ -125,8 +125,9 @@ function (_Component) {
                 _context.prev = 11;
                 _context.t0 = _context["catch"](2);
                 isError = true;
-                this.handleError(_context.t0);
-                this.props.handleEditingTimespans(0); // Fetch structure.json when waveform.json is
+                this.handleError(_context.t0); // Disable edting when waveform is missing
+
+                this.props.handleEditingTimespans(1); // Fetch structure.json when waveform.json is
 
                 this.props.fetchDataAndBuildPeaks(baseURL, masterFileID, initStructure, peaksOptions, streamLength, isError);
 

--- a/dist/reducers/forms.js
+++ b/dist/reducers/forms.js
@@ -23,7 +23,7 @@ var forms = function forms() {
 
   switch (action.type) {
     case types.IS_EDITING_TIMESPAN:
-      if (action.code === 0) {
+      if (action.code === 1) {
         return Object.assign({}, state, {
           editingDisabled: true
         });

--- a/src/components/ButtonSection.js
+++ b/src/components/ButtonSection.js
@@ -38,7 +38,7 @@ class ButtonSection extends Component {
       disabled: true
     });
     // Clear the redux-store flag when closing the alert from AlertContainer
-    this.props.handleEditingTimespans(1);
+    this.props.handleEditingTimespans(0);
   };
 
   handleCancelHeadingClick = () => {
@@ -47,7 +47,7 @@ class ButtonSection extends Component {
   };
 
   handleHeadingClick = () => {
-    this.props.handleEditingTimespans(0);
+    this.props.handleEditingTimespans(1);
     // When opening heading form, delete if a temporary segment exists
     this.deleteTempSegment();
     this.setState({
@@ -69,7 +69,7 @@ class ButtonSection extends Component {
     this.clearAlert();
 
     // Disable editing other items in structure
-    this.props.handleEditingTimespans(0);
+    this.props.handleEditingTimespans(1);
 
     // Create a temporary segment if timespan form is closed
     if (!this.state.timespanOpen) {

--- a/src/components/ListItem.js
+++ b/src/components/ListItem.js
@@ -61,23 +61,13 @@ class ListItem extends Component {
   handleDelete = () => {
     const { item } = this.props;
 
-    // Remove DnD source & targets if the current item was active
-    if (this.props.item.active) {
-      this.handleShowDropTargetsClick();
-    }
-
     this.props.deleteItem(item.id);
     this.props.deleteSegment(item);
   };
 
   handleEditClick = () => {
     // Disable the edit buttons of other list items
-    this.props.handleEditingTimespans(0);
-
-    // Remove DnD source & targets if the current item was active
-    if (this.props.item.active) {
-      this.handleShowDropTargetsClick();
-    }
+    this.props.handleEditingTimespans(1);
 
     this.setState({ editing: true });
   };
@@ -86,7 +76,7 @@ class ListItem extends Component {
     this.setState({ editing: false });
 
     // Enable the edit buttons of other list items
-    this.props.handleEditingTimespans(1);
+    this.props.handleEditingTimespans(0);
   };
 
   handleShowDropTargetsClick = () => {
@@ -98,6 +88,9 @@ class ListItem extends Component {
       setActiveDragSource
     } = this.props;
 
+    // Disable other editing actions
+    this.props.handleEditingTimespans(1);
+
     // Clear out any current drop targets
     removeDropTargets();
 
@@ -105,6 +98,8 @@ class ListItem extends Component {
     if (item.active === true) {
       // Clear out any active drag sources
       removeActiveDragSources();
+      // Enable other editing actions
+      this.props.handleEditingTimespans(0);
       return;
     }
     // Clear out any active drag sources
@@ -134,7 +129,8 @@ class ListItem extends Component {
     const itemProp = {
       childrenCount: item.items ? item.items.length : 0,
       label: item.label,
-      type: item.type
+      type: item.type,
+      active: item.active
     };
 
     return connectDragSource(
@@ -184,7 +180,8 @@ const mapDispatchToProps = {
 };
 
 const mapStateToProps = state => ({
-  smData: state.smData
+  smData: state.smData,
+  peaksInstance: state.peaksInstance.peaks
 });
 
 const ConnectedDropTarget = DropTarget(ItemTypes.SPAN, spanTarget, collectDrop);

--- a/src/components/ListItemControls.js
+++ b/src/components/ListItemControls.js
@@ -36,7 +36,7 @@ class ListItemControls extends Component {
 
   enableEditing() {
     // Enable editing of other list items
-    this.props.handleEditingTimespans(1);
+    this.props.handleEditingTimespans(0);
   }
 
   handleConfirmDelete = () => {
@@ -55,7 +55,7 @@ class ListItemControls extends Component {
     deleteMessage += `?`;
 
     // Disable editing of other list items
-    this.props.handleEditingTimespans(0);
+    this.props.handleEditingTimespans(1);
 
     this.setState({
       deleteMessage,
@@ -85,7 +85,7 @@ class ListItemControls extends Component {
         {item.type === 'span' && (
           <Button
             bsStyle="link"
-            disabled={forms.editingDisabled}
+            disabled={forms.editingDisabled && !item.active}
             onClick={handleShowDropTargetsClick}
           >
             <FontAwesomeIcon icon="dot-circle" />

--- a/src/containers/WaveformContainer.js
+++ b/src/containers/WaveformContainer.js
@@ -77,7 +77,10 @@ class WaveformContainer extends Component {
     } catch (error) {
       isError = true;
       this.handleError(error);
-      this.props.handleEditingTimespans(0);
+
+      // Disable edting when waveform is missing
+      this.props.handleEditingTimespans(1);
+
       // Fetch structure.json when waveform.json is
       this.props.fetchDataAndBuildPeaks(
         baseURL,

--- a/src/reducers/forms.js
+++ b/src/reducers/forms.js
@@ -11,7 +11,7 @@ const initialState = {
 const forms = (state = initialState, action) => {
   switch (action.type) {
     case types.IS_EDITING_TIMESPAN:
-      if (action.code === 0) {
+      if (action.code === 1) {
         return Object.assign({}, state, {
           editingDisabled: true
         });


### PR DESCRIPTION
This fixes an issue mentioned in avalonmediasystem/avalon#3334

> Only one editing mode should be available to be used at one time. The two modes are rearranging (dra and drop) and editing. If one is active, the other should be disabled.



Additionally, changed the code passed in the redux store action `handleEditingTimespans` to turn on and off disabling other editing actions when one action is performed. Previously it was;
```
if(code === 0) {
  set editingDisabled: true;
}
```
Now, using 1 for boolean value `true` according to common practice;

```
if (code === 1) {
  set editingDisabled: true;
}
```
There is no logic changes in the application regarding this, but the values passed to the function.