### PR TITLE
Bug fix in volume slider

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -45,10 +45,6 @@ section {
   margin-bottom: 10px;
 }
 
-.btn {
-  height: 40px;
-}
-
 /* Waveform */
 .waveform-container,
 .zoom-container,

--- a/src/components/Slider.js
+++ b/src/components/Slider.js
@@ -58,7 +58,6 @@ function VolumeSlider(props) {
   const [prevValue, setPrevValue] = React.useState(100);
 
   const handleChange = (e, value) => {
-    setPrevValue(value);
     props.setVolume(value);
   };
 


### PR DESCRIPTION
Intended behavior: when slider is dragged until volume is 0 and then clicked on the volume icon, the volume should set to the previous value (the volume the slider was at before dragging it).
This did not happen as the previous volume was constantly set when slider was dragged, which is removed in this PR.