### PR TITLE
Fix missing file endtime passed in to build SM-UI

### DIFF
--- a/dist/actions/peaks-instance.js
+++ b/dist/actions/peaks-instance.js
@@ -53,7 +53,7 @@ function initializeSMDataPeaks(baseURL, masterFileID, initStructure, options, du
       var _ref = (0, _asyncToGenerator2["default"])(
       /*#__PURE__*/
       _regenerator["default"].mark(function _callee(dispatch, getState) {
-        var response, smData, initSmData, _getState, peaksInstance, status;
+        var response, smData, _getState, structuralMetadata, _getState2, peaksInstance, status;
 
         return _regenerator["default"].wrap(function _callee$(_context) {
           while (1) {
@@ -71,20 +71,20 @@ function initializeSMDataPeaks(baseURL, masterFileID, initStructure, options, du
                   smData = structuralMetadataUtils.addUUIds([JSON.parse(initStructure)]);
                 } else {
                   smData = structuralMetadataUtils.addUUIds([response.data]);
-                }
+                } // Mark the top element as 'root'
 
-                initSmData = smData;
-                dispatch((0, _smData.saveInitialStructure)(initSmData)); // Mark the top element as 'root'
 
                 structuralMetadataUtils.markRootElement(smData); // Initialize Redux state variable with structure
 
-                dispatch((0, _smData.buildSMUI)(smData, duration)); // Update redux-store flag for structure file retrieval
+                dispatch((0, _smData.buildSMUI)(smData, duration));
+                _getState = getState(), structuralMetadata = _getState.structuralMetadata;
+                dispatch((0, _smData.saveInitialStructure)(structuralMetadata.smData)); // Update redux-store flag for structure file retrieval
 
                 dispatch((0, _forms.retrieveStructureSuccess)());
 
                 if (!isError) {
                   dispatch(initPeaks(smData, options));
-                  _getState = getState(), peaksInstance = _getState.peaksInstance; // Subscribe to Peaks event for dragging handles in a segment
+                  _getState2 = getState(), peaksInstance = _getState2.peaksInstance; // Subscribe to Peaks event for dragging handles in a segment
 
                   if (peaksInstance.events !== undefined) {
                     peaksInstance.events.subscribe(function (segment) {

--- a/dist/containers/WaveformContainer.js
+++ b/dist/containers/WaveformContainer.js
@@ -73,7 +73,8 @@ function (_Component) {
       hasError: false,
       masterFileID: _this.props.masterFileID,
       baseURL: _this.props.baseURL,
-      initStructure: _this.props.initStructure
+      initStructure: _this.props.initStructure,
+      streamLength: _this.props.streamDuration
     });
     (0, _defineProperty2["default"])((0, _assertThisInitialized2["default"])(_this), "clearAlert", function () {
       _this.setState({

--- a/src/actions/peaks-instance.js
+++ b/src/actions/peaks-instance.js
@@ -38,14 +38,15 @@ export function initializeSMDataPeaks(
       } else {
         smData = structuralMetadataUtils.addUUIds([response.data]);
       }
-      const initSmData = smData;
-      dispatch(saveInitialStructure(initSmData));
 
       // Mark the top element as 'root'
       structuralMetadataUtils.markRootElement(smData);
 
       // Initialize Redux state variable with structure
       dispatch(buildSMUI(smData, duration));
+
+      const { structuralMetadata } = getState();
+      dispatch(saveInitialStructure(structuralMetadata.smData));
 
       // Update redux-store flag for structure file retrieval
       dispatch(retrieveStructureSuccess());

--- a/src/containers/WaveformContainer.js
+++ b/src/containers/WaveformContainer.js
@@ -36,7 +36,8 @@ class WaveformContainer extends Component {
     hasError: false,
     masterFileID: this.props.masterFileID,
     baseURL: this.props.baseURL,
-    initStructure: this.props.initStructure
+    initStructure: this.props.initStructure,
+    streamLength: this.props.streamDuration
   };
 
   componentDidMount() {


### PR DESCRIPTION
Add missing `duration` property passed into `buildSMUI` function to fill in missing end property within structure fetched from server. The state variable `streamLength` in `WaveformContainer` was removed when merging the file.