### PR TITLE
Always operate in thousandths of a second

### DIFF
--- a/__mocks__/peaks.js
+++ b/__mocks__/peaks.js
@@ -60,24 +60,24 @@ export const Peaks = jest.fn(opts => {
     _segments: [
       new Segment({
         parent: peaks,
-        startTime: 3.32,
-        endTime: 10.32,
+        startTime: 3.321,
+        endTime: 10.321,
         id: '123a-456b-789c-3d',
         labelText: 'Segment 1.1',
         color: '#80A590'
       }),
       new Segment({
         parent: peaks,
-        startTime: 11.23,
-        endTime: 480,
+        startTime: 11.231,
+        endTime: 480.001,
         id: '123a-456b-789c-4d',
         labelText: 'Segment 1.2',
         color: '#2A5459'
       }),
       new Segment({
         parent: peaks,
-        startTime: 543.24,
-        endTime: 900,
+        startTime: 543.241,
+        endTime: 900.001,
         id: '123a-456b-789c-8d',
         labelText: 'Segment 2.1',
         color: '#80A590'

--- a/dist/components/Slider.js
+++ b/dist/components/Slider.js
@@ -7,7 +7,7 @@ Object.defineProperty(exports, "__esModule", {
 });
 exports["default"] = VolumeSlider;
 
-var _objectSpread2 = _interopRequireDefault(require("@babel/runtime/helpers/objectSpread"));
+var _defineProperty2 = _interopRequireDefault(require("@babel/runtime/helpers/defineProperty"));
 
 var _slicedToArray2 = _interopRequireDefault(require("@babel/runtime/helpers/slicedToArray"));
 
@@ -23,12 +23,10 @@ var _core = require("@material-ui/core");
 
 var _reactBootstrap = require("react-bootstrap");
 
-/**
- * NOTE:
- * The logic of turning on/off volume in this module is taken from,
- * https://github.com/digirati-co-uk/timeliner/blob/master/src/components/VolumeSliderCompact/VolumeSliderCompact.js
- *
- */
+function ownKeys(object, enumerableOnly) { var keys = Object.keys(object); if (Object.getOwnPropertySymbols) { keys.push.apply(keys, Object.getOwnPropertySymbols(object)); } if (enumerableOnly) keys = keys.filter(function (sym) { return Object.getOwnPropertyDescriptor(object, sym).enumerable; }); return keys; }
+
+function _objectSpread(target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i] != null ? arguments[i] : {}; if (i % 2) { ownKeys(source, true).forEach(function (key) { (0, _defineProperty2["default"])(target, key, source[key]); }); } else if (Object.getOwnPropertyDescriptors) { Object.defineProperties(target, Object.getOwnPropertyDescriptors(source)); } else { ownKeys(source).forEach(function (key) { Object.defineProperty(target, key, Object.getOwnPropertyDescriptor(source, key)); }); } } return target; }
+
 var useStyles = (0, _styles.makeStyles)(function () {
   return {
     root: {
@@ -112,11 +110,11 @@ function VolumeSlider(props) {
       paddingRight: 15
     }
   }, props.volume === 0 ? _react["default"].createElement(_VolumeOff["default"], {
-    style: (0, _objectSpread2["default"])({}, SPEAKER_ICON_SIZE, {
+    style: _objectSpread({}, SPEAKER_ICON_SIZE, {
       transform: 'translateX(1px)'
     })
   }) : _react["default"].createElement(_VolumeUp["default"], {
-    style: (0, _objectSpread2["default"])({}, SPEAKER_ICON_SIZE, {
+    style: _objectSpread({}, SPEAKER_ICON_SIZE, {
       transform: 'translateX(1px)'
     })
   }))), _react["default"].createElement(_reactBootstrap.Col, {

--- a/dist/components/__tests__/ButtonSection.test.js
+++ b/dist/components/__tests__/ButtonSection.test.js
@@ -100,10 +100,10 @@ describe('timespan button', () => {
     });
     // Begin Time and End Time is already filled with default values
     expect(buttonSection.getAllByPlaceholderText('00:00:00')[0].value).toBe(
-      '00:00:00.00'
+      '00:00:00.000'
     );
     expect(buttonSection.getAllByPlaceholderText('00:00:00')[1].value).toBe(
-      '00:00:03.32'
+      '00:00:03.321'
     );
     // Save button is disabled
     expect(

--- a/dist/components/__tests__/ListItem.test.js
+++ b/dist/components/__tests__/ListItem.test.js
@@ -25,7 +25,7 @@ const initialState = {
     isDragging: false,
     segment: {
       startTime: 0,
-      endTime: 3.32,
+      endTime: 3.321,
       label: '',
       id: 'temp-segment',
       editable: true,
@@ -51,8 +51,8 @@ const spanItem = {
   type: 'span',
   label: 'Segment 1.1',
   id: '123a-456b-789c-3d',
-  begin: '00:00:03.32',
-  end: '00:00:10.32'
+  begin: '00:00:03.321',
+  end: '00:00:10.321'
 };
 const divItemWithChildren = {
   type: 'div',
@@ -74,8 +74,8 @@ const divItemWithChildren = {
           type: 'span',
           label: 'Segment 2.1',
           id: '123a-456b-789c-8d',
-          begin: '00:09:03.24',
-          end: '00:15:00.00'
+          begin: '00:09:03.241',
+          end: '00:15:00.001'
         }
       ]
     }

--- a/dist/components/__tests__/ListItemEditForm.test.js
+++ b/dist/components/__tests__/ListItemEditForm.test.js
@@ -51,8 +51,8 @@ test("ListItemEditForm renders TimespanInlineForm for item with type 'span'", ()
     type: 'span',
     label: 'Segment 1.2',
     id: '123a-456b-789c-4d',
-    begin: '00:00:11.23',
-    end: '00:08:00.00'
+    begin: '00:00:11.231',
+    end: '00:08:00.001'
   };
 
   const { getByTestId } = renderWithRedux(
@@ -70,8 +70,8 @@ test('clicking on cancel button calls the mock function for cancelling the form'
     type: 'span',
     label: 'Segment 1.2',
     id: '123a-456b-789c-4d',
-    begin: '00:00:11.23',
-    end: '00:08:00.00'
+    begin: '00:00:11.231',
+    end: '00:08:00.001'
   };
 
   const { getByTestId } = renderWithRedux(

--- a/dist/components/__tests__/TimespanForm.test.js
+++ b/dist/components/__tests__/TimespanForm.test.js
@@ -25,7 +25,7 @@ const initialState = {
     isDragging: false,
     segment: {
       startTime: 0,
-      endTime: 3.32,
+      endTime: 3.321,
       labelText: '',
       id: 'temp-segment',
       editable: true,
@@ -43,7 +43,7 @@ const cancelMock = jest.fn();
 const props = {
   initSegment: {
     startTime: 0,
-    endTime: 3.32,
+    endTime: 3.321,
     editable: true,
     color: '#FBB040',
     id: 'temp-segment'
@@ -76,8 +76,8 @@ test('initial render with default begin/end time and save button disabled', () =
   expect(getByTestId('timespan-form-save-button')).toBeDisabled();
 
   // Begin Time and End Time is filled with default values
-  expect(getAllByPlaceholderText('00:00:00')[0].value).toBe('00:00:00.00');
-  expect(getAllByPlaceholderText('00:00:00')[1].value).toBe('00:00:03.32');
+  expect(getAllByPlaceholderText('00:00:00')[0].value).toBe('00:00:00.000');
+  expect(getAllByPlaceholderText('00:00:00')[1].value).toBe('00:00:03.321');
 
   // Child Of options list is filled with valid headings
   const childOfSelect = container.querySelector('#timespanChildOf');
@@ -159,7 +159,7 @@ describe('shows proper validation messages for begin/end time changes and save b
 
     const endTimeInput = timespanForm.getByLabelText(/end time/i);
     fireEvent.change(endTimeInput, {
-      target: { value: '00:00:04.00' }
+      target: { value: '00:00:04.001' }
     });
 
     expect(
@@ -184,7 +184,7 @@ describe('shows proper validation messages for begin/end time changes and save b
 
     const beginTimeInput = timespanForm.getByLabelText(/begin time/i);
     fireEvent.change(beginTimeInput, {
-      target: { value: '00:00:05.00' }
+      target: { value: '00:00:05.001' }
     });
 
     expect(
@@ -233,8 +233,8 @@ describe('submitting the form', () => {
   });
   test('save the new timespan', () => {
     const expectedPayload = {
-      beginTime: '00:00:00.00',
-      endTime: '00:00:03.32',
+      beginTime: '00:00:00.000',
+      endTime: '00:00:03.321',
       timespanChildOf: '123a-456b-789c-2d',
       timespanTitle: 'New Timespan'
     };

--- a/dist/components/__tests__/TimespanInlineForm.test.js
+++ b/dist/components/__tests__/TimespanInlineForm.test.js
@@ -37,8 +37,8 @@ const props = {
     type: 'span',
     label: 'Segment 2.1',
     id: '123a-456b-789c-8d',
-    begin: '00:09:03.24',
-    end: '00:15:00.00'
+    begin: '00:09:03.241',
+    end: '00:15:00.001'
   },
   isTyping: false,
   isInitializing: true,
@@ -55,8 +55,8 @@ test('TimespanInlineForm renders with existing values', () => {
   );
   expect(getByTestId('timespan-inline-form')).toBeInTheDocument();
   expect(getByLabelText(/title/i).value).toBe('Segment 2.1');
-  expect(getByLabelText(/begin time/i).value).toBe('00:09:03.24');
-  expect(getByLabelText(/end time/i).value).toBe('00:15:00.00');
+  expect(getByLabelText(/begin time/i).value).toBe('00:09:03.241');
+  expect(getByLabelText(/end time/i).value).toBe('00:15:00.001');
 });
 
 test('timespan title input shows proper validation messages', () => {
@@ -100,7 +100,7 @@ test('shows proper validation messages for begin/end time changes and save butto
   expect(saveButton).toBeDisabled();
 
   fireEvent.change(beginTimeInput, {
-    target: { value: '00:09:00.00' }
+    target: { value: '00:09:00.001' }
   });
   expect(beginTimeForm.classList.contains('has-error')).toBeFalsy();
   expect(beginTimeForm.classList.contains('has-success')).toBeTruthy();
@@ -124,8 +124,8 @@ describe('form changes when segment in the waveform change', () => {
       peaksInstance: {
         peaks: Peaks.init(peaksOptions),
         segment: {
-          startTime: 450, // changed from 00:09:03.24 -> 00:07:30.00
-          endTime: 900,
+          startTime: 450.001, // changed from 00:09:03.241 -> 00:07:30.001
+          endTime: 900.001,
           labelText: 'Segment 2.1',
           id: '123a-456b-789c-8d',
           editable: true,
@@ -139,13 +139,13 @@ describe('form changes when segment in the waveform change', () => {
       nextState
     );
 
-    // expects begin value to be the last possible valid value: 00:08:00.00
+    // expects begin value to be the last possible valid value: 00:08:00.001
     expect(timespanInlineForm.getByLabelText(/begin time/i).value).toBe(
-      '00:08:00.00'
+      '00:08:00.001'
     );
     // end time does not change
     expect(timespanInlineForm.getByLabelText(/end time/i).value).toBe(
-      '00:15:00.00'
+      '00:15:00.001'
     );
     expect(saveButton).toBeEnabled();
   });
@@ -158,8 +158,8 @@ describe('form changes when segment in the waveform change', () => {
       peaksInstance: {
         peaks: Peaks.init(peaksOptions),
         segment: {
-          startTime: 540, // changed from 00:09:03.24 -> 00:09:00.00
-          endTime: 900,
+          startTime: 540.001, // changed from 00:09:03.241 -> 00:09:00.001
+          endTime: 900.001,
           labelText: 'Segment 2.1',
           id: '123a-456b-789c-8d',
           editable: true,
@@ -174,11 +174,11 @@ describe('form changes when segment in the waveform change', () => {
     );
 
     expect(timespanInlineForm.getByLabelText(/begin time/i).value).toBe(
-      '00:09:00.00'
+      '00:09:00.001'
     );
     // end time does not change
     expect(timespanInlineForm.getByLabelText(/end time/i).value).toBe(
-      '00:15:00.00'
+      '00:15:00.001'
     );
     expect(saveButton).toBeEnabled();
   });
@@ -192,14 +192,14 @@ describe('submit the inline timespan form', () => {
       { initialState }
     );
     fireEvent.change(timespanInlineForm.getByLabelText(/end time/i), {
-      target: { value: '00:10:00.00' }
+      target: { value: '00:10:00.001' }
     });
   });
   test('save the edited timespan', () => {
     fireEvent.click(timespanInlineForm.getByTestId('inline-form-save-button'));
     expect(saveFnMock).toHaveBeenCalledWith('123a-456b-789c-8d', {
-      beginTime: '00:09:03.24',
-      endTime: '00:10:00.00',
+      beginTime: '00:09:03.241',
+      endTime: '00:10:00.001',
       timespanTitle: 'Segment 2.1'
     });
     expect(saveFnMock).toHaveBeenCalledTimes(1);

--- a/dist/data/mock-response-structure.json
+++ b/dist/data/mock-response-structure.json
@@ -1,1 +1,64 @@
-{"type":"div","label":"j3860704z-utah_phillips_one_2018.mp3","items":[{"type":"div","label":"First segment","items":[{"type":"div","label":"Sub-Segment 1.1","items":[]},{"type":"span","label":"Segment 1.1","begin":"00:00:03.32","end":"00:00:10.32"},{"type":"span","label":"Segment 1.2","begin":"00:00:11.23","end":"00:09:03.23"}]},{"type":"div","label":"Second segment","items":[{"type":"div","label":"Sub-Segment 2.1","items":[{"type":"div","label":"Sub-Segment 2.1.1","items":[]},{"type":"span","label":"Segment 2.1","begin":"00:09:03.24","end":"00:15:00.00"}]}]},{"type":"div","label":"Excellent Third Segment Series","items":[{"type":"span","label":"Spannn","begin":"00:15:01.00","end":"00:21:00.00"}]}]}
+{
+    "type": "div",
+    "label": "j3860704z-utah_phillips_one_2018.mp3",
+    "items": [
+        {
+            "type": "div",
+            "label": "First segment",
+            "items": [
+                {
+                    "type": "div",
+                    "label": "Sub-Segment 1.1",
+                    "items": []
+                },
+                {
+                    "type": "span",
+                    "label": "Segment 1.1",
+                    "begin": "00:00:03.321",
+                    "end": "00:00:10.321"
+                },
+                {
+                    "type": "span",
+                    "label": "Segment 1.2",
+                    "begin": "00:00:11.231",
+                    "end": "00:09:03.231"
+                }
+            ]
+        },
+        {
+            "type": "div",
+            "label": "Second segment",
+            "items": [
+                {
+                    "type": "div",
+                    "label": "Sub-Segment 2.1",
+                    "items": [
+                        {
+                            "type": "div",
+                            "label": "Sub-Segment 2.1.1",
+                            "items": []
+                        },
+                        {
+                            "type": "span",
+                            "label": "Segment 2.1",
+                            "begin": "00:09:03.241",
+                            "end": "00:15:00.001"
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "type": "div",
+            "label": "Excellent Third Segment Series",
+            "items": [
+                {
+                    "type": "span",
+                    "label": "Spannn",
+                    "begin": "00:15:01.001",
+                    "end": "00:21:00.001"
+                }
+            ]
+        }
+    ]
+}

--- a/dist/reducers/peaks-instance.js
+++ b/dist/reducers/peaks-instance.js
@@ -9,7 +9,7 @@ Object.defineProperty(exports, "__esModule", {
 });
 exports["default"] = void 0;
 
-var _objectSpread2 = _interopRequireDefault(require("@babel/runtime/helpers/objectSpread"));
+var _defineProperty2 = _interopRequireDefault(require("@babel/runtime/helpers/defineProperty"));
 
 var types = _interopRequireWildcard(require("../actions/types"));
 
@@ -18,6 +18,10 @@ var _WaveformDataUtils = _interopRequireDefault(require("../services/WaveformDat
 var _peaks = _interopRequireDefault(require("peaks.js"));
 
 var _rxjs = require("rxjs");
+
+function ownKeys(object, enumerableOnly) { var keys = Object.keys(object); if (Object.getOwnPropertySymbols) { keys.push.apply(keys, Object.getOwnPropertySymbols(object)); } if (enumerableOnly) keys = keys.filter(function (sym) { return Object.getOwnPropertyDescriptor(object, sym).enumerable; }); return keys; }
+
+function _objectSpread(target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i] != null ? arguments[i] : {}; if (i % 2) { ownKeys(source, true).forEach(function (key) { (0, _defineProperty2["default"])(target, key, source[key]); }); } else if (Object.getOwnPropertyDescriptors) { Object.defineProperties(target, Object.getOwnPropertyDescriptors(source)); } else { ownKeys(source).forEach(function (key) { Object.defineProperty(target, key, Object.getOwnPropertyDescriptor(source, key)); }); } } return target; }
 
 var waveformUtils = new _WaveformDataUtils["default"]();
 var initialState = {
@@ -37,80 +41,80 @@ var peaksInstance = function peaksInstance() {
     case types.INIT_PEAKS:
       var segments = waveformUtils.initSegments(action.smData);
 
-      var _peaksInstance = _peaks["default"].init((0, _objectSpread2["default"])({}, action.options, {
+      var _peaksInstance = _peaks["default"].init(_objectSpread({}, action.options, {
         segments: segments
       }));
 
       return {
         peaks: _peaksInstance,
         events: (0, _rxjs.fromEvent)(_peaksInstance, 'segments.dragged'),
-        segment: (0, _objectSpread2["default"])({}, state.segment)
+        segment: _objectSpread({}, state.segment)
       };
 
     case types.INSERT_SEGMENT:
       state.peaks.segments.add(waveformUtils.convertTimespanToSegment(action.payload));
-      newPeaks = waveformUtils.rebuildPeaks((0, _objectSpread2["default"])({}, state.peaks));
-      return (0, _objectSpread2["default"])({}, state, {
+      newPeaks = waveformUtils.rebuildPeaks(_objectSpread({}, state.peaks));
+      return _objectSpread({}, state, {
         peaks: newPeaks
       });
 
     case types.DELETE_SEGMENT:
-      newPeaks = waveformUtils.deleteSegments(action.payload, (0, _objectSpread2["default"])({}, state.peaks));
-      return (0, _objectSpread2["default"])({}, state, {
+      newPeaks = waveformUtils.deleteSegments(action.payload, _objectSpread({}, state.peaks));
+      return _objectSpread({}, state, {
         peaks: waveformUtils.rebuildPeaks(newPeaks)
       });
 
     case types.ACTIVATE_SEGMENT:
-      newPeaks = waveformUtils.activateSegment(action.payload, (0, _objectSpread2["default"])({}, state.peaks));
-      return (0, _objectSpread2["default"])({}, state, {
+      newPeaks = waveformUtils.activateSegment(action.payload, _objectSpread({}, state.peaks));
+      return _objectSpread({}, state, {
         peaks: newPeaks
       });
 
     case types.SAVE_SEGMENT:
-      newPeaks = waveformUtils.deactivateSegment(action.payload.clonedSegment.id, (0, _objectSpread2["default"])({}, state.peaks));
-      var rebuiltPeaks = waveformUtils.saveSegment(action.payload, (0, _objectSpread2["default"])({}, newPeaks));
-      return (0, _objectSpread2["default"])({}, state, {
+      newPeaks = waveformUtils.deactivateSegment(action.payload.clonedSegment.id, _objectSpread({}, state.peaks));
+      var rebuiltPeaks = waveformUtils.saveSegment(action.payload, _objectSpread({}, newPeaks));
+      return _objectSpread({}, state, {
         peaks: rebuiltPeaks
       });
 
     case types.REVERT_SEGMENT:
-      newPeaks = waveformUtils.deactivateSegment(action.payload.id, (0, _objectSpread2["default"])({}, state.peaks));
-      return (0, _objectSpread2["default"])({}, state, {
-        peaks: waveformUtils.revertSegment(action.payload, (0, _objectSpread2["default"])({}, newPeaks))
+      newPeaks = waveformUtils.deactivateSegment(action.payload.id, _objectSpread({}, state.peaks));
+      return _objectSpread({}, state, {
+        peaks: waveformUtils.revertSegment(action.payload, _objectSpread({}, newPeaks))
       });
 
     case types.UPDATE_SEGMENT:
-      newPeaks = waveformUtils.updateSegment(action.segment, action.state, (0, _objectSpread2["default"])({}, state.peaks));
+      newPeaks = waveformUtils.updateSegment(action.segment, action.state, _objectSpread({}, state.peaks));
       updatedSegment = newPeaks.segments.getSegment(action.segment.id);
-      return (0, _objectSpread2["default"])({}, state, {
-        peaks: (0, _objectSpread2["default"])({}, newPeaks),
+      return _objectSpread({}, state, {
+        peaks: _objectSpread({}, newPeaks),
         segment: updatedSegment
       });
 
     case types.IS_DRAGGING:
       if (action.flag === 0) {
-        return (0, _objectSpread2["default"])({}, state, {
+        return _objectSpread({}, state, {
           segment: action.segment,
           isDragging: false
         });
       }
 
       if (action.flag === 1) {
-        return (0, _objectSpread2["default"])({}, state, {
+        return _objectSpread({}, state, {
           segment: action.segment,
           isDragging: true
         });
       }
 
     case types.TEMP_INSERT_SEGMENT:
-      newPeaks = waveformUtils.insertTempSegment((0, _objectSpread2["default"])({}, state.peaks));
-      return (0, _objectSpread2["default"])({}, state, {
-        peaks: (0, _objectSpread2["default"])({}, newPeaks)
+      newPeaks = waveformUtils.insertTempSegment(_objectSpread({}, state.peaks));
+      return _objectSpread({}, state, {
+        peaks: _objectSpread({}, newPeaks)
       });
 
     case types.TEMP_DELETE_SEGMENT:
       state.peaks.segments.removeById(action.payload);
-      return (0, _objectSpread2["default"])({}, state);
+      return _objectSpread({}, state);
 
     default:
       return state;

--- a/dist/reducers/sm-data.js
+++ b/dist/reducers/sm-data.js
@@ -9,13 +9,17 @@ Object.defineProperty(exports, "__esModule", {
 });
 exports["default"] = void 0;
 
-var _objectSpread2 = _interopRequireDefault(require("@babel/runtime/helpers/objectSpread"));
+var _defineProperty2 = _interopRequireDefault(require("@babel/runtime/helpers/defineProperty"));
 
 var types = _interopRequireWildcard(require("../actions/types"));
 
 var _StructuralMetadataUtils = _interopRequireDefault(require("../services/StructuralMetadataUtils"));
 
 var _lodash = require("lodash");
+
+function ownKeys(object, enumerableOnly) { var keys = Object.keys(object); if (Object.getOwnPropertySymbols) { keys.push.apply(keys, Object.getOwnPropertySymbols(object)); } if (enumerableOnly) keys = keys.filter(function (sym) { return Object.getOwnPropertyDescriptor(object, sym).enumerable; }); return keys; }
+
+function _objectSpread(target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i] != null ? arguments[i] : {}; if (i % 2) { ownKeys(source, true).forEach(function (key) { (0, _defineProperty2["default"])(target, key, source[key]); }); } else if (Object.getOwnPropertyDescriptors) { Object.defineProperties(target, Object.getOwnPropertyDescriptors(source)); } else { ownKeys(source).forEach(function (key) { Object.defineProperty(target, key, Object.getOwnPropertyDescriptor(source, key)); }); } } return target; }
 
 var structuralMetadataUtils = new _StructuralMetadataUtils["default"]();
 var initialState = {
@@ -32,30 +36,30 @@ var structuralMetadata = function structuralMetadata() {
   switch (action.type) {
     case types.BUILD_SM_UI:
       newState = structuralMetadataUtils.buildSMUI(action.json, action.duration);
-      return (0, _objectSpread2["default"])({}, state, {
+      return _objectSpread({}, state, {
         smData: newState
       });
 
     case types.SAVE_INIT_SMDATA:
-      return (0, _objectSpread2["default"])({}, state, {
+      return _objectSpread({}, state, {
         initSmData: action.payload
       });
 
     case types.DELETE_ITEM:
       newState = structuralMetadataUtils.deleteListItem(action.id, state.smData);
-      return (0, _objectSpread2["default"])({}, state, {
+      return _objectSpread({}, state, {
         smData: newState
       });
 
     case types.ADD_DROP_TARGETS:
       newState = structuralMetadataUtils.determineDropTargets(action.payload, state.smData);
-      return (0, _objectSpread2["default"])({}, state, {
+      return _objectSpread({}, state, {
         smData: newState
       });
 
     case types.REMOVE_DROP_TARGETS:
       var noDropTargetsState = structuralMetadataUtils.removeDropTargets(state.smData);
-      return (0, _objectSpread2["default"])({}, state, {
+      return _objectSpread({}, state, {
         smData: noDropTargetsState
       });
 
@@ -64,19 +68,19 @@ var structuralMetadata = function structuralMetadata() {
       var target = structuralMetadataUtils.findItem(action.id, stateClone.smData); // Put an active flag on list item
 
       target.active = true;
-      return (0, _objectSpread2["default"])({}, stateClone, {
+      return _objectSpread({}, stateClone, {
         smData: stateClone.smData
       });
 
     case types.REMOVE_ACTIVE_DRAG_SOURCES:
       var noActiveDragSourcesState = structuralMetadataUtils.removeActiveDragSources(state.smData);
-      return (0, _objectSpread2["default"])({}, state, {
+      return _objectSpread({}, state, {
         smData: noActiveDragSourcesState
       });
 
     case types.HANDLE_LIST_ITEM_DROP:
       newState = structuralMetadataUtils.handleListItemDrop(action.dragSource, action.dropTarget, state.smData);
-      return (0, _objectSpread2["default"])({}, state, {
+      return _objectSpread({}, state, {
         smData: newState
       });
 

--- a/dist/services/StructuralMetadataUtils.js
+++ b/dist/services/StructuralMetadataUtils.js
@@ -9,8 +9,6 @@ exports["default"] = void 0;
 
 var _objectWithoutProperties2 = _interopRequireDefault(require("@babel/runtime/helpers/objectWithoutProperties"));
 
-var _objectSpread2 = _interopRequireDefault(require("@babel/runtime/helpers/objectSpread"));
-
 var _slicedToArray2 = _interopRequireDefault(require("@babel/runtime/helpers/slicedToArray"));
 
 var _classCallCheck2 = _interopRequireDefault(require("@babel/runtime/helpers/classCallCheck"));
@@ -24,6 +22,10 @@ var _lodash = require("lodash");
 var _moment = _interopRequireDefault(require("moment"));
 
 var _v = _interopRequireDefault(require("uuid/v1"));
+
+function ownKeys(object, enumerableOnly) { var keys = Object.keys(object); if (Object.getOwnPropertySymbols) { keys.push.apply(keys, Object.getOwnPropertySymbols(object)); } if (enumerableOnly) keys = keys.filter(function (sym) { return Object.getOwnPropertyDescriptor(object, sym).enumerable; }); return keys; }
+
+function _objectSpread(target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i] != null ? arguments[i] : {}; if (i % 2) { ownKeys(source, true).forEach(function (key) { (0, _defineProperty2["default"])(target, key, source[key]); }); } else if (Object.getOwnPropertyDescriptors) { Object.defineProperties(target, Object.getOwnPropertyDescriptors(source)); } else { ownKeys(source).forEach(function (key) { Object.defineProperty(target, key, Object.getOwnPropertyDescriptor(source, key)); }); } } return target; }
 
 /**
  * Rules - https://github.com/avalonmediasystem/avalon/issues/3022
@@ -154,9 +156,7 @@ function () {
 
       // Regex to match mm:ss OR single number
       var regexMMSS = /^([0-9]*:[0-9]*.[0-9]*)$/i;
-      var regexSS = /^([0-9]*.[0-9]*)$/i; // Round duration to 2 decimal places
-
-      var fileLength = Math.round(duration / 10) / 100; // Convert time to HH:mm:ss.ms format to use in validation logic
+      var regexSS = /^([0-9]*.[0-9]*)$/i; // Convert time to HH:mm:ss.ms format to use in validation logic
 
       var convertToHHmmss = function convertToHHmmss(time) {
         if (regexMMSS.test(time)) {
@@ -195,7 +195,7 @@ function () {
               item.begin = _this2.toHHmmss(beginTime);
 
               if (beginTime > endTime) {
-                item.end = _this2.toHHmmss(fileLength);
+                item.end = _this2.toHHmmss(duration);
               } else {
                 item.end = _this2.toHHmmss(endTime);
               }
@@ -489,7 +489,8 @@ function () {
             var item = _step3.value;
 
             if (item.type === type) {
-              var currentObj = (0, _objectSpread2["default"])({}, item);
+              var currentObj = _objectSpread({}, item);
+
               delete currentObj.items;
               options.push(currentObj);
             }
@@ -1003,7 +1004,7 @@ function () {
       var seconds = sec_num - minutes * 60 - hours * 3600;
       var hourStr = hours < 10 ? "0".concat(hours) : "".concat(hours);
       var minStr = minutes < 10 ? "0".concat(minutes) : "".concat(minutes);
-      var secStr = seconds.toFixed(2);
+      var secStr = seconds.toFixed(3);
       secStr = seconds < 10 ? "0".concat(secStr) : "".concat(secStr);
       return "".concat(hourStr, ":").concat(minStr, ":").concat(secStr);
     }
@@ -1020,7 +1021,7 @@ function () {
       if (!decVal) {
         valueString = intVal;
       } else {
-        valueString = intVal + '.' + decVal.substring(0, 2);
+        valueString = intVal + '.' + decVal.substring(0, 3);
       }
 
       return parseFloat(valueString);

--- a/dist/services/StructuralMetadataUtils.test.js
+++ b/dist/services/StructuralMetadataUtils.test.js
@@ -22,8 +22,8 @@ describe('StructuralMetadataUtils class', () => {
 
   test('creates a helper span object', () => {
     const obj = {
-      beginTime: '00:00:01',
-      endTime: '00:00:02',
+      beginTime: '00:00:011',
+      endTime: '00:00:021',
       timespanChildOf: '3bf42620-2321-11e9-aa56-f9563015e266',
       timespanTitle: 'Tester'
     };
@@ -31,8 +31,8 @@ describe('StructuralMetadataUtils class', () => {
 
     expect(value).toHaveProperty('id');
     expect(value).toHaveProperty('type', 'span');
-    expect(value).toHaveProperty('begin', '00:00:01');
-    expect(value).toHaveProperty('end', '00:00:02');
+    expect(value).toHaveProperty('begin', '00:00:011');
+    expect(value).toHaveProperty('end', '00:00:021');
     expect(value).toHaveProperty('label', 'Tester');
   });
 
@@ -50,8 +50,8 @@ describe('StructuralMetadataUtils class', () => {
         type: 'span',
         label: 'Segment 1.1',
         id: '123a-456b-789c-3d',
-        begin: '00:00:03.32',
-        end: '00:00:10.32'
+        begin: '00:00:03.321',
+        end: '00:00:10.321'
       });
     });
     test('deletes a header with children', () => {
@@ -70,15 +70,15 @@ describe('StructuralMetadataUtils class', () => {
             type: 'span',
             label: 'Segment 1.1',
             id: '123a-456b-789c-3d',
-            begin: '00:00:03.32',
-            end: '00:00:10.32'
+            begin: '00:00:03.321',
+            end: '00:00:10.321'
           },
           {
             type: 'span',
             label: 'Segment 1.2',
             id: '123a-456b-789c-4d',
-            begin: '00:00:11.23',
-            end: '00:08:00.00'
+            begin: '00:00:11.231',
+            end: '00:08:00.001'
           }
         ]
       };
@@ -104,8 +104,8 @@ describe('StructuralMetadataUtils class', () => {
         type: 'span',
         label: 'Segment 2.1',
         id: '123a-456b-789c-8d',
-        begin: '00:09:03.24',
-        end: '00:15:00.00'
+        begin: '00:09:03.241',
+        end: '00:15:00.001'
       });
     });
   });
@@ -115,24 +115,24 @@ describe('StructuralMetadataUtils class', () => {
     beforeEach(() => {
       allSpans = smu.getItemsOfType('span', testData);
     });
-    test('time == 00:00:00.00 (before the first timespan)', () => {
-      const time = '00:00:00.00';
+    test('time == 00:00:00.000 (before the first timespan)', () => {
+      const time = '00:00:00.000';
       expect(smu.doesTimeOverlap(time, allSpans)).toBeTruthy();
     });
-    test('time = 00:00:03.32 (start of the first timespan)', () => {
-      const time = '00:00:03.32';
+    test('time = 00:00:03.321 (start of the first timespan)', () => {
+      const time = '00:00:03.321';
       expect(smu.doesTimeOverlap(time, allSpans)).toBeTruthy();
     });
-    test('time == 00:00:05.00 (within an existing timespan)', () => {
-      const time = '00:00:05.00';
+    test('time == 00:00:05.001 (within an existing timespan)', () => {
+      const time = '00:00:05.001';
       expect(smu.doesTimeOverlap(time, allSpans)).toBeFalsy();
     });
-    test('time == 00:00:10.45 (between existing timespans)', () => {
-      const time = '00:00:10.45';
+    test('time == 00:00:10.451 (between existing timespans)', () => {
+      const time = '00:00:10.451';
       expect(smu.doesTimeOverlap(time, allSpans)).toBeTruthy();
     });
-    test('time == 00:15.00.00 (end of the last timespan)', () => {
-      const time = '00:15.00.00';
+    test('time == 00:15:00.001 (end of the last timespan)', () => {
+      const time = '00:15:00.001';
       expect(smu.doesTimeOverlap(time, allSpans)).toBeTruthy();
     });
   });
@@ -144,16 +144,16 @@ describe('StructuralMetadataUtils class', () => {
     });
     test('timespan overlapping an existing timespan', () => {
       const value = smu.doesTimespanOverlap(
-        '00:00:00.00',
-        '00:00:05.00',
+        '00:00:00.000',
+        '00:00:05.001',
         allSpans
       );
       expect(value).toBeTruthy();
     });
     test('timespan not overlapping an existing timespan', () => {
       const value = smu.doesTimespanOverlap(
-        '00:15:00.00',
-        '00:18:00.00',
+        '00:15:00.001',
+        '00:18:00.001',
         allSpans
       );
       expect(value).toBeFalsy();
@@ -178,16 +178,16 @@ describe('StructuralMetadataUtils class', () => {
     });
     test('before first timespan', () => {
       const obj = {
-        begin: '00:00:00.00',
-        end: '00:00:03.32'
+        begin: '00:00:00.000',
+        end: '00:00:03.321'
       };
       const expected = {
         before: null,
         after: {
           type: 'span',
           label: 'Segment 1.1',
-          begin: '00:00:03.32',
-          end: '00:00:10.32',
+          begin: '00:00:03.321',
+          end: '00:00:10.321',
           id: '123a-456b-789c-3d'
         }
       };
@@ -196,23 +196,23 @@ describe('StructuralMetadataUtils class', () => {
     });
     test('in between existing timespans', () => {
       const obj = {
-        begin: '00:00:10.32',
-        end: '00:00:11.23'
+        begin: '00:00:10.321',
+        end: '00:00:11.231'
       };
       const expected = {
         before: {
           type: 'span',
           label: 'Segment 1.1',
-          begin: '00:00:03.32',
-          end: '00:00:10.32',
+          begin: '00:00:03.321',
+          end: '00:00:10.321',
           id: '123a-456b-789c-3d'
         },
         after: {
           type: 'span',
           label: 'Segment 1.2',
           id: '123a-456b-789c-4d',
-          begin: '00:00:11.23',
-          end: '00:08:00.00'
+          begin: '00:00:11.231',
+          end: '00:08:00.001'
         }
       };
       const value = smu.findWrapperSpans(obj, allSpans);
@@ -220,15 +220,15 @@ describe('StructuralMetadataUtils class', () => {
     });
     test('after last timespan', () => {
       const obj = {
-        begin: '00:15:00.00',
-        end: '00:20:00.00'
+        begin: '00:15:00.001',
+        end: '00:20:00.001'
       };
       const expected = {
         before: {
           type: 'span',
           label: 'Segment 2.1',
-          begin: '00:09:03.24',
-          end: '00:15:00.00',
+          begin: '00:09:03.241',
+          end: '00:15:00.001',
           id: '123a-456b-789c-8d'
         },
         after: null
@@ -249,8 +249,8 @@ describe('StructuralMetadataUtils class', () => {
             type: 'span',
             label: 'Act 1',
             id: '123a-456b-789c-3d',
-            begin: '00:10:00.00',
-            end: '00:15:00.00'
+            begin: '00:10:00.001',
+            end: '00:15:00.001'
           }
         ]
       };
@@ -276,8 +276,8 @@ describe('StructuralMetadataUtils class', () => {
             type: 'span',
             label: 'Act 1',
             id: '123a-456b-789c-2d',
-            begin: '00:00:00.00',
-            end: '00:09:00.00'
+            begin: '00:00:00.000',
+            end: '00:09:00.001'
           }
         ]
       };
@@ -343,22 +343,22 @@ describe('StructuralMetadataUtils class', () => {
           type: 'span',
           label: 'Segment 1.1',
           id: '123a-456b-789c-3d',
-          begin: '00:00:03.32',
-          end: '00:00:10.32'
+          begin: '00:00:03.321',
+          end: '00:00:10.321'
         },
         {
           type: 'span',
           label: 'Segment 1.2',
           id: '123a-456b-789c-4d',
-          begin: '00:00:11.23',
-          end: '00:08:00.00'
+          begin: '00:00:11.231',
+          end: '00:08:00.001'
         },
         {
           type: 'span',
           label: 'Segment 2.1',
           id: '123a-456b-789c-8d',
-          begin: '00:09:03.24',
-          end: '00:15:00.00'
+          begin: '00:09:03.241',
+          end: '00:15:00.001'
         }
       ];
       const value = smu.getItemsOfType('span', testData);
@@ -367,8 +367,8 @@ describe('StructuralMetadataUtils class', () => {
         type: 'span',
         label: 'Segment 2.1',
         id: '123a-456b-789c-8d',
-        begin: '00:09:03.24',
-        end: '00:15:00.00'
+        begin: '00:09:03.241',
+        end: '00:15:00.001'
       });
     });
   });
@@ -379,8 +379,8 @@ describe('StructuralMetadataUtils class', () => {
         type: 'span',
         label: 'Segment 1.2',
         id: '123a-456b-789c-4d',
-        begin: '00:00:11.23',
-        end: '00:08:00.00'
+        begin: '00:00:11.231',
+        end: '00:08:00.001'
       };
       const expected = {
         type: 'div',
@@ -397,15 +397,15 @@ describe('StructuralMetadataUtils class', () => {
             type: 'span',
             label: 'Segment 1.1',
             id: '123a-456b-789c-3d',
-            begin: '00:00:03.32',
-            end: '00:00:10.32'
+            begin: '00:00:03.321',
+            end: '00:00:10.321'
           },
           {
             type: 'span',
             label: 'Segment 1.2',
             id: '123a-456b-789c-4d',
-            begin: '00:00:11.23',
-            end: '00:08:00.00'
+            begin: '00:00:11.231',
+            end: '00:08:00.001'
           }
         ]
       };
@@ -434,8 +434,8 @@ describe('StructuralMetadataUtils class', () => {
             type: 'span',
             label: 'Segment 2.1',
             id: '123a-456b-789c-8d',
-            begin: '00:09:03.24',
-            end: '00:15:00.00'
+            begin: '00:09:03.241',
+            end: '00:15:00.001'
           }
         ]
       };
@@ -446,7 +446,7 @@ describe('StructuralMetadataUtils class', () => {
 
   describe('finds valid headings when adding/editing a timespan', () => {
     test('no existing timespans', () => {
-      const newSpan = { begin: '00:00:00.01', end: '00:02:00.00' };
+      const newSpan = { begin: '00:00:00.011', end: '00:02:00.001' };
       const wrapperSpans = {
         before: null,
         after: null
@@ -498,21 +498,21 @@ describe('StructuralMetadataUtils class', () => {
       });
     });
     test('wrapped by existing timespans', () => {
-      const newSpan = { begin: '00:08:00.00', end: '00:09:00.00' };
+      const newSpan = { begin: '00:08:00.001', end: '00:09:00.001' };
       const wrapperSpans = {
         before: {
           type: 'span',
           label: 'Segment 1.2',
           id: '123a-456b-789c-4d',
-          begin: '00:00:11.23',
-          end: '00:08:00.00'
+          begin: '00:00:11.231',
+          end: '00:08:00.001'
         },
         after: {
           type: 'span',
           label: 'Segment 2.1',
           id: '123a-456b-789c-8d',
-          begin: '00:09:03.24',
-          end: '00:15:00.00'
+          begin: '00:09:03.241',
+          end: '00:15:00.001'
         }
       };
       const expected = [
@@ -546,14 +546,14 @@ describe('StructuralMetadataUtils class', () => {
       });
     });
     test('no wrapping timespans after', () => {
-      const newSpan = { begin: '00:15:00.00', end: '00:16:00.00' };
+      const newSpan = { begin: '00:15:00.001', end: '00:16:00.001' };
       const wrapperSpans = {
         before: {
           type: 'span',
           label: 'Segment 2.1',
           id: '123a-456b-789c-8d',
-          begin: '00:09:03.24',
-          end: '00:15:00.00'
+          begin: '00:09:03.241',
+          end: '00:15:00.001'
         },
         after: null
       };
@@ -583,15 +583,15 @@ describe('StructuralMetadataUtils class', () => {
       });
     });
     test('no wrapping span before', () => {
-      const newSpan = { begin: '00:00:00.00', end: '00:00:03.32' };
+      const newSpan = { begin: '00:00:00.000', end: '00:00:03.321' };
       const wrapperSpans = {
         before: null,
         after: {
           type: 'span',
           label: 'Act 1',
           id: '123a-456b-789c-3d',
-          begin: '00:00:03.32',
-          end: '00:00:10.32'
+          begin: '00:00:03.321',
+          end: '00:00:10.321'
         }
       };
       const expected = [
@@ -623,20 +623,20 @@ describe('StructuralMetadataUtils class', () => {
 
   describe('validates order of begin and end times', () => {
     test('begin time < end time', () => {
-      const begin = '00:00:10.30';
-      const end = '00:10:00.30';
+      const begin = '00:00:10.301';
+      const end = '00:10:00.301';
       const value = smu.validateBeforeEndTimeOrder(begin, end);
       expect(value).toBeTruthy();
     });
     test('begin time === end time', () => {
-      const begin = '00:00:10.30';
-      const end = '00:00:10.30';
+      const begin = '00:00:10.301';
+      const end = '00:00:10.301';
       const value = smu.validateBeforeEndTimeOrder(begin, end);
       expect(value).toBeFalsy();
     });
     test('begin time > end time', () => {
-      const begin = '00:10:00.30';
-      const end = '00:00:10.30';
+      const begin = '00:10:00.301';
+      const end = '00:00:10.301';
       const value = smu.validateBeforeEndTimeOrder(begin, end);
       expect(value).toBeFalsy();
     });
@@ -644,19 +644,19 @@ describe('StructuralMetadataUtils class', () => {
 
   describe('converts time in seconds to string hh:mm:ss.ss format', () => {
     test('when time is an integer', () => {
-      const timeInSeconds = 540.0;
+      const timeInSeconds = 540.001;
       const value = smu.toHHmmss(timeInSeconds);
-      expect(value).toEqual('00:09:00.00');
+      expect(value).toEqual('00:09:00.001');
     });
     test('when there are decimal points', () => {
       const timeInSeconds = 543.9983255;
       const value = smu.toHHmmss(timeInSeconds);
-      expect(value).toEqual('00:09:03.99');
+      expect(value).toEqual('00:09:03.998');
     });
     test('when decimal with zero at the end', () => {
-      const timeInSeconds = 545.2;
+      const timeInSeconds = 545.201;
       const value = smu.toHHmmss(timeInSeconds);
-      expect(value).toEqual('00:09:05.20');
+      expect(value).toEqual('00:09:05.201');
     });
   });
 });

--- a/dist/services/WaveformDataUtils.js
+++ b/dist/services/WaveformDataUtils.js
@@ -9,11 +9,15 @@ exports["default"] = void 0;
 
 var _slicedToArray2 = _interopRequireDefault(require("@babel/runtime/helpers/slicedToArray"));
 
-var _objectSpread2 = _interopRequireDefault(require("@babel/runtime/helpers/objectSpread"));
+var _defineProperty2 = _interopRequireDefault(require("@babel/runtime/helpers/defineProperty"));
 
 var _classCallCheck2 = _interopRequireDefault(require("@babel/runtime/helpers/classCallCheck"));
 
 var _createClass2 = _interopRequireDefault(require("@babel/runtime/helpers/createClass"));
+
+function ownKeys(object, enumerableOnly) { var keys = Object.keys(object); if (Object.getOwnPropertySymbols) { keys.push.apply(keys, Object.getOwnPropertySymbols(object)); } if (enumerableOnly) keys = keys.filter(function (sym) { return Object.getOwnPropertyDescriptor(object, sym).enumerable; }); return keys; }
+
+function _objectSpread(target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i] != null ? arguments[i] : {}; if (i % 2) { ownKeys(source, true).forEach(function (key) { (0, _defineProperty2["default"])(target, key, source[key]); }); } else if (Object.getOwnPropertyDescriptors) { Object.defineProperties(target, Object.getOwnPropertyDescriptors(source)); } else { ownKeys(source).forEach(function (key) { Object.defineProperty(target, key, Object.getOwnPropertyDescriptor(source, key)); }); } } return target; }
 
 // Colors for segments from Avalon branding pallette
 var COLOR_PALETTE = ['#80A590', '#2A5459', '#FBB040'];
@@ -52,7 +56,7 @@ function () {
 
               var segment = _this.convertTimespanToSegment(item);
 
-              initSegments.push((0, _objectSpread2["default"])({}, segment, {
+              initSegments.push(_objectSpread({}, segment, {
                 color: COLOR_PALETTE[count]
               }));
               count++;
@@ -102,7 +106,7 @@ function () {
 
       currentSegments.map(function (segment) {
         if (rangeBeginTime >= segment.startTime && rangeBeginTime <= segment.endTime) {
-          // rounds upto 2 decimal points for accuracy
+          // rounds upto 3 decimal points for accuracy
           rangeBeginTime = _this2.roundOff(segment.endTime);
         }
 
@@ -110,9 +114,9 @@ function () {
       }); // Set the default end time of the temporary segment
 
       if (currentSegments.length === 0) {
-        rangeEndTime = fileEndTime < 60 ? fileEndTime : Math.round((rangeBeginTime + 60.0) * 100) / 100;
+        rangeEndTime = fileEndTime < 60 ? fileEndTime : Math.round((rangeBeginTime + 60.0) * 1000) / 1000;
       } else {
-        rangeEndTime = Math.round((rangeBeginTime + 60.0) * 100) / 100;
+        rangeEndTime = Math.round((rangeBeginTime + 60.0) * 1000) / 1000;
       } // Validate end time of the temporary segment
 
 
@@ -370,8 +374,8 @@ function () {
 
         if (startTime > current.startTime && endTime < current.endTime) {
           segment.startTime = current.endTime;
-          segment.endTime = current.endTime + 0.01;
-        } else if (duration - 0.01 <= endTime && endTime <= duration && after && after.id === current.id) {
+          segment.endTime = current.endTime + 0.001;
+        } else if (duration - 0.001 <= endTime && endTime <= duration && after && after.id === current.id) {
           segment.endTime = after.startTime;
         } else if (before && before.id === current.id && startTime < before.endTime) {
           segment.startTime = before.endTime;
@@ -382,7 +386,7 @@ function () {
         } else if (endTime > current.startTime && endTime < current.endTime) {
           segment.endTime = i < segmentIndex ? current.startTime : current.endTime;
         } else if (segment.startTime === segment.endTime) {
-          segment.endTime = segment.startTime + 0.01;
+          segment.endTime = segment.startTime + 0.001;
         } else if (endTime > duration) {
           segment.endTime = duration;
         }
@@ -427,7 +431,7 @@ function () {
       var startTime = currentSegment.startTime,
           endTime = currentSegment.endTime;
       var timeFixedSegments = allSegments.map(function (seg) {
-        return (0, _objectSpread2["default"])({}, seg, {
+        return _objectSpread({}, seg, {
           startTime: _this4.roundOff(seg.startTime),
           endTime: _this4.roundOff(seg.endTime)
         });
@@ -461,7 +465,7 @@ function () {
 
       var hoursAndMins = parseInt(hours) * 3600 + parseInt(minutes) * 60;
       var secondsIn = seconds === '' ? 0.0 : parseFloat(seconds);
-      return hoursAndMins + secondsIn;
+      return Math.round((hoursAndMins + secondsIn) * 1000) / 1000;
     }
   }, {
     key: "sortSegments",
@@ -485,7 +489,7 @@ function () {
       if (!decVal) {
         valueString = intVal;
       } else {
-        valueString = intVal + '.' + decVal.substring(0, 2);
+        valueString = intVal + '.' + decVal.substring(0, 3);
       }
 
       return parseFloat(valueString);

--- a/dist/services/WaveformDataUtils.test.js
+++ b/dist/services/WaveformDataUtils.test.js
@@ -17,22 +17,22 @@ describe('WaveformDataUtils class', () => {
   test('initializes peaks segments with metadata structure', () => {
     const expected = [
       {
-        startTime: 3.32,
-        endTime: 10.32,
+        startTime: 3.321,
+        endTime: 10.321,
         labelText: 'Segment 1.1',
         id: '123a-456b-789c-3d',
         color: '#80A590'
       },
       {
-        startTime: 11.23,
-        endTime: 480,
+        startTime: 11.231,
+        endTime: 480.001,
         labelText: 'Segment 1.2',
         id: '123a-456b-789c-4d',
         color: '#2A5459'
       },
       {
-        startTime: 543.24,
-        endTime: 900,
+        startTime: 543.241,
+        endTime: 900.001,
         labelText: 'Segment 2.1',
         id: '123a-456b-789c-8d',
         color: '#80A590'
@@ -67,7 +67,7 @@ describe('WaveformDataUtils class', () => {
           expect.arrayContaining([
             expect.objectContaining({
               startTime: 0,
-              endTime: 3.32,
+              endTime: 3.321,
               id: 'temp-segment',
               color: '#FBB040',
               editable: true
@@ -77,81 +77,81 @@ describe('WaveformDataUtils class', () => {
         expect(value.player.getCurrentTime()).toEqual(0);
       });
       test('when current time is in between an existing segment', () => {
-        peaks.player.seek(450);
+        peaks.player.seek(450.001);
         const value = waveformUtils.insertTempSegment(peaks);
         expect(value.segments._segments).toEqual(
           expect.arrayContaining([
             expect.objectContaining({
-              startTime: 480.0,
-              endTime: 540.0,
+              startTime: 480.001,
+              endTime: 540.001,
               id: 'temp-segment',
               color: '#FBB040',
               editable: true
             })
           ])
         );
-        expect(value.player.getCurrentTime()).toEqual(480.0);
+        expect(value.player.getCurrentTime()).toEqual(480.001);
       });
 
       test('when current time is at the end time of an existing timespan', () => {
-        peaks.player.seek(480.0);
+        peaks.player.seek(480.001);
         const value = waveformUtils.insertTempSegment(peaks);
         expect(value.segments._segments).toEqual(
           expect.arrayContaining([
             expect.objectContaining({
-              startTime: 480.0,
-              endTime: 540.0,
+              startTime: 480.001,
+              endTime: 540.001,
               id: 'temp-segment',
               color: '#FBB040',
               editable: true
             })
           ])
         );
-        expect(value.player.getCurrentTime()).toEqual(480.0);
+        expect(value.player.getCurrentTime()).toEqual(480.001);
       });
 
       test('when current time is at the begin time of an existing timespan', () => {
-        peaks.player.seek(543.24);
+        peaks.player.seek(543.241);
         const value = waveformUtils.insertTempSegment(peaks);
         expect(value.segments._segments).toEqual(
           expect.arrayContaining([
             expect.objectContaining({
-              startTime: 900.0,
-              endTime: 960.0,
+              startTime: 900.001,
+              endTime: 960.001,
               id: 'temp-segment',
               color: '#FBB040',
               editable: true
             })
           ])
         );
-        expect(value.player.getCurrentTime()).toEqual(900.0);
+        expect(value.player.getCurrentTime()).toEqual(900.001);
       });
 
       test('when end time of temporary segment overlaps existing segment', () => {
-        peaks.player.seek(520);
+        peaks.player.seek(520.001);
         const value = waveformUtils.insertTempSegment(peaks);
         expect(value.segments._segments).toEqual(
           expect.arrayContaining([
             expect.objectContaining({
-              startTime: 520,
-              endTime: 543.24,
+              startTime: 520.001,
+              endTime: 543.241,
               id: 'temp-segment',
               color: '#FBB040',
               editable: true
             })
           ])
         );
-        expect(value.player.getCurrentTime()).toEqual(520);
+        expect(value.player.getCurrentTime()).toEqual(520.001);
       });
 
       test('when current playhead time + 60 > duration of the media file', () => {
-        peaks.player.seek(1680);
+        peaks.player.seek(1680.001);
         const value = waveformUtils.insertTempSegment(peaks);
         expect(value.segments._segments).toEqual(
           expect.arrayContaining([
             expect.objectContaining({
-              startTime: 1680,
-              endTime: 1738.94,
+              startTime: 1680.001,
+              endTime: 1738.945,
               id: 'temp-segment',
               color: '#FBB040',
               editable: true
@@ -162,19 +162,19 @@ describe('WaveformDataUtils class', () => {
 
       test('when there are multiple small segments with a length of less than 60 seconds', () => {
         peaks.segments.add({
-          startTime: 1690,
-          endTime: 1738.95,
+          startTime: 1690.001,
+          endTime: 1738.951,
           id: '123a-456b-789c-9d',
           color: '#2A5459',
           labelText: 'Test segment'
         });
-        peaks.player.seek(450);
+        peaks.player.seek(450.001);
         const value = waveformUtils.insertTempSegment(peaks);
         expect(value.segments._segments).toEqual(
           expect.arrayContaining([
             expect.objectContaining({
-              startTime: 480.0,
-              endTime: 540.0,
+              startTime: 480.001,
+              endTime: 540.001,
               id: 'temp-segment',
               color: '#FBB040',
               editable: true
@@ -190,8 +190,8 @@ describe('WaveformDataUtils class', () => {
           type: 'span',
           label: 'Segment 1.2',
           id: '123a-456b-789c-4d',
-          begin: '00:00:11.23',
-          end: '00:08:00.00'
+          begin: '00:00:11.231',
+          end: '00:08:00.001'
         };
         const value = waveformUtils.deleteSegments(item, peaks);
         expect(value.segments._segments).toHaveLength(2);
@@ -224,8 +224,8 @@ describe('WaveformDataUtils class', () => {
               type: 'span',
               label: 'Segment 2.1',
               id: '123a-456b-789c-8d',
-              begin: '00:09:03.24',
-              end: '00:15:00.00'
+              begin: '00:09:03.241',
+              end: '00:15:00.001'
             }
           ]
         };
@@ -245,8 +245,8 @@ describe('WaveformDataUtils class', () => {
     describe('rebuilds waveform', () => {
       test('when a segment is added in between existing segments', () => {
         peaks.segments.add({
-          startTime: 500,
-          endTime: 540,
+          startTime: 500.001,
+          endTime: 540.001,
           id: '123a-456b-789c-9d',
           labelText: 'Added segment'
         });
@@ -323,8 +323,8 @@ describe('WaveformDataUtils class', () => {
     test('saves changes to an existing segment', () => {
       const clonedSegment = peaks.segments.getSegment('123a-456b-789c-4d');
       const currentState = {
-        beginTime: '00:00:10.33',
-        endTime: '00:08:00.00',
+        beginTime: '00:00:10.331',
+        endTime: '00:08:00.001',
         clonedSegment
       };
       const value = waveformUtils.saveSegment(currentState, peaks);
@@ -333,8 +333,8 @@ describe('WaveformDataUtils class', () => {
       expect(segments).toEqual(
         expect.arrayContaining([
           expect.objectContaining({
-            startTime: 10.33,
-            endTime: 480,
+            startTime: 10.331,
+            endTime: 480.001,
             id: '123a-456b-789c-4d'
           })
         ])
@@ -345,22 +345,22 @@ describe('WaveformDataUtils class', () => {
       let segment;
       beforeEach(() => {
         segment = {
-          startTime: 11.23,
-          endTime: 480,
+          startTime: 11.231,
+          endTime: 480.001,
           id: '123a-456b-789c-4d',
           labelText: 'Segment 1.2',
           color: '#2A5459'
         };
       });
       test('start time = 00:03:', () => {
-        const currentState = { beginTime: '00:03:', endTime: '00:08:00.00' };
+        const currentState = { beginTime: '00:03:', endTime: '00:08:00.001' };
         const value = waveformUtils.updateSegment(segment, currentState, peaks);
         const segments = value.segments.getSegments();
         expect(segments).toHaveLength(3);
         expect(segments).toEqual(
           expect.arrayContaining([
             expect.objectContaining({
-              startTime: 180,
+              startTime: 180.000,
               id: '123a-456b-789c-4d'
             })
           ])
@@ -368,24 +368,24 @@ describe('WaveformDataUtils class', () => {
       });
 
       test('start time = 00:03:59', () => {
-        const currentState = { beginTime: '00:03:59', endTime: '00:08:00.00' };
+        const currentState = { beginTime: '00:03:59', endTime: '00:08:00.001' };
         const value = waveformUtils.updateSegment(segment, currentState, peaks);
         const segments = value.segments.getSegments();
         expect(segments).toHaveLength(3);
         expect(segments).toEqual(
           expect.arrayContaining([
             expect.objectContaining({
-              startTime: 239,
+              startTime: 239.000,
               id: '123a-456b-789c-4d'
             })
           ])
         );
       });
 
-      test('start time = 00:03:59.99', () => {
+      test('start time = 00:03:59.991', () => {
         const currentState = {
-          beginTime: '00:03:59.99',
-          endTime: '00:08:00.00'
+          beginTime: '00:03:59.991',
+          endTime: '00:08:00.001'
         };
         const value = waveformUtils.updateSegment(segment, currentState, peaks);
         const segments = value.segments.getSegments();
@@ -393,7 +393,7 @@ describe('WaveformDataUtils class', () => {
         expect(segments).toEqual(
           expect.arrayContaining([
             expect.objectContaining({
-              startTime: 239.99,
+              startTime: 239.991,
               id: '123a-456b-789c-4d'
             })
           ])
@@ -404,19 +404,19 @@ describe('WaveformDataUtils class', () => {
     describe('prevents overlapping with existing segments', () => {
       test('when start time of an editing segment overlaps segment before', () => {
         const testSegment = {
-          startTime: 480,
-          endTime: 500,
+          startTime: 480.001,
+          endTime: 500.001,
           editable: true,
           id: 'test-segment',
           color: '#FBB040'
         };
         peaks.segments.add(testSegment);
         // Change start time to overlap with previous segment
-        testSegment.startTime = 479;
+        testSegment.startTime = 479.001;
         const value = waveformUtils.validateSegment(testSegment, peaks);
         expect(value).toEqual({
-          startTime: 480.0,
-          endTime: 500,
+          startTime: 480.001,
+          endTime: 500.001,
           editable: true,
           id: 'test-segment',
           color: '#FBB040'
@@ -425,19 +425,19 @@ describe('WaveformDataUtils class', () => {
 
       test('when end time of an editing segment overlaps segment after', () => {
         const testSegment = {
-          startTime: 490.99,
-          endTime: 540,
+          startTime: 490.991,
+          endTime: 540.001,
           editable: true,
           id: 'test-segment',
           color: '#FBB040'
         };
         peaks.segments.add(testSegment);
         // Change end time to overlap with following segment
-        testSegment.endTime = 543.25;
+        testSegment.endTime = 543.251;
         const value = waveformUtils.validateSegment(testSegment, peaks);
         expect(value).toEqual({
-          startTime: 490.99,
-          endTime: 543.24,
+          startTime: 490.991,
+          endTime: 543.241,
           editable: true,
           id: 'test-segment',
           color: '#FBB040'
@@ -446,19 +446,19 @@ describe('WaveformDataUtils class', () => {
 
       test('when a segment does not overlap neighboring segments', () => {
         const testSegment = {
-          startTime: 499.99,
-          endTime: 529.99,
+          startTime: 499.991,
+          endTime: 529.991,
           editable: true,
           id: 'test-segment',
           color: '#FBB040'
         };
         peaks.segments.add(testSegment);
         // Change end time of the segment
-        testSegment.endTime = 540.99;
+        testSegment.endTime = 540.991;
         const value = waveformUtils.validateSegment(testSegment, peaks);
         expect(value).toEqual({
-          startTime: 499.99,
-          endTime: 540.99,
+          startTime: 499.991,
+          endTime: 540.991,
           editable: true,
           id: 'test-segment',
           color: '#FBB040'
@@ -467,19 +467,19 @@ describe('WaveformDataUtils class', () => {
 
       test('when a segment overlaps the end time of the media file', () => {
         const testSegment = {
-          startTime: 1200.99,
-          endTime: 1699.99,
+          startTime: 1200.991,
+          endTime: 1699.991,
           editable: true,
           id: 'test-segment',
           color: '#FBB040'
         };
         peaks.segments.add(testSegment);
         // Change the end time to exceed the end time of the media file
-        testSegment.endTime = 1740;
+        testSegment.endTime = 1740.001;
         const value = waveformUtils.validateSegment(testSegment, peaks);
         expect(value).toEqual({
-          startTime: 1200.99,
-          endTime: 1738.94,
+          startTime: 1200.991,
+          endTime: 1738.945,
           editable: true,
           id: 'test-segment',
           color: '#FBB040'
@@ -488,19 +488,19 @@ describe('WaveformDataUtils class', () => {
 
       test('when there is a segment going until the end of the file over an existing segment', () => {
         const testSegment = {
-          startTime: 540.0,
-          endTime: 1738.94,
+          startTime: 540.001,
+          endTime: 1738.945,
           editable: true,
           id: 'test-segment',
           color: '#FBB040'
         };
         peaks.segments.add(testSegment);
         // Change the start time of the segment
-        testSegment.startTime = 541.43;
+        testSegment.startTime = 541.431;
         const value = waveformUtils.validateSegment(testSegment, peaks);
         expect(value).toEqual({
-          startTime: 541.43,
-          endTime: 543.24,
+          startTime: 541.431,
+          endTime: 543.241,
           editable: true,
           id: 'test-segment',
           color: '#FBB040'

--- a/dist/services/testing-helpers.js
+++ b/dist/services/testing-helpers.js
@@ -8,7 +8,7 @@ Object.defineProperty(exports, "__esModule", {
 exports.renderWithRedux = renderWithRedux;
 exports.testEmptyHeaderAfter = exports.testEmptyHeaderBefore = exports.testSmData = void 0;
 
-var _objectSpread2 = _interopRequireDefault(require("@babel/runtime/helpers/objectSpread"));
+var _defineProperty2 = _interopRequireDefault(require("@babel/runtime/helpers/defineProperty"));
 
 var _react = _interopRequireDefault(require("react"));
 
@@ -21,6 +21,10 @@ var _reactTestingLibrary = require("react-testing-library");
 var _reducers = _interopRequireDefault(require("../reducers"));
 
 var _reduxThunk = _interopRequireDefault(require("redux-thunk"));
+
+function ownKeys(object, enumerableOnly) { var keys = Object.keys(object); if (Object.getOwnPropertySymbols) { keys.push.apply(keys, Object.getOwnPropertySymbols(object)); } if (enumerableOnly) keys = keys.filter(function (sym) { return Object.getOwnPropertyDescriptor(object, sym).enumerable; }); return keys; }
+
+function _objectSpread(target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i] != null ? arguments[i] : {}; if (i % 2) { ownKeys(source, true).forEach(function (key) { (0, _defineProperty2["default"])(target, key, source[key]); }); } else if (Object.getOwnPropertyDescriptors) { Object.defineProperties(target, Object.getOwnPropertyDescriptors(source)); } else { ownKeys(source).forEach(function (key) { Object.defineProperty(target, key, Object.getOwnPropertyDescriptor(source, key)); }); } } return target; }
 
 /**
  * Helper function for providing a Redux connected component for testing.
@@ -40,7 +44,8 @@ function renderWithRedux(ui) {
       store = _ref$store === void 0 ? (0, _redux.createStore)(_reducers["default"], initialState, (0, _redux.applyMiddleware)(_reduxThunk["default"])) : _ref$store;
 
   var renderFn = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : _reactTestingLibrary.render;
-  var obj = (0, _objectSpread2["default"])({}, renderFn(_react["default"].createElement(_reactRedux.Provider, {
+
+  var obj = _objectSpread({}, renderFn(_react["default"].createElement(_reactRedux.Provider, {
     store: store
   }, ui)), {
     store: store
@@ -82,14 +87,14 @@ var testSmData = [{
       type: 'span',
       label: 'Segment 1.1',
       id: '123a-456b-789c-3d',
-      begin: '00:00:03.32',
-      end: '00:00:10.32'
+      begin: '00:00:03.321',
+      end: '00:00:10.321'
     }, {
       type: 'span',
       label: 'Segment 1.2',
       id: '123a-456b-789c-4d',
-      begin: '00:00:11.23',
-      end: '00:08:00.00'
+      begin: '00:00:11.231',
+      end: '00:08:00.001'
     }]
   }, {
     type: 'div',
@@ -108,8 +113,8 @@ var testSmData = [{
         type: 'span',
         label: 'Segment 2.1',
         id: '123a-456b-789c-8d',
-        begin: '00:09:03.24',
-        end: '00:15:00.00'
+        begin: '00:09:03.241',
+        end: '00:15:00.001'
       }]
     }]
   }, {
@@ -137,8 +142,8 @@ var testEmptyHeaderBefore = [{
       type: 'span',
       label: 'Act 1',
       id: '123a-456b-789c-3d',
-      begin: '00:10:00.00',
-      end: '00:15:00.00'
+      begin: '00:10:00.001',
+      end: '00:15:00.001'
     }]
   }]
 }];
@@ -155,8 +160,8 @@ var testEmptyHeaderAfter = [{
       type: 'span',
       label: 'Act 1',
       id: '123a-456b-789c-2d',
-      begin: '00:00:00.00',
-      end: '00:09:00.00'
+      begin: '00:00:00.000',
+      end: '00:09:00.001'
     }]
   }, {
     type: 'div',

--- a/src/components/__tests__/ButtonSection.test.js
+++ b/src/components/__tests__/ButtonSection.test.js
@@ -100,10 +100,10 @@ describe('timespan button', () => {
     });
     // Begin Time and End Time is already filled with default values
     expect(buttonSection.getAllByPlaceholderText('00:00:00')[0].value).toBe(
-      '00:00:00.00'
+      '00:00:00.000'
     );
     expect(buttonSection.getAllByPlaceholderText('00:00:00')[1].value).toBe(
-      '00:00:03.32'
+      '00:00:03.321'
     );
     // Save button is disabled
     expect(

--- a/src/components/__tests__/ListItem.test.js
+++ b/src/components/__tests__/ListItem.test.js
@@ -25,7 +25,7 @@ const initialState = {
     isDragging: false,
     segment: {
       startTime: 0,
-      endTime: 3.32,
+      endTime: 3.321,
       label: '',
       id: 'temp-segment',
       editable: true,
@@ -51,8 +51,8 @@ const spanItem = {
   type: 'span',
   label: 'Segment 1.1',
   id: '123a-456b-789c-3d',
-  begin: '00:00:03.32',
-  end: '00:00:10.32'
+  begin: '00:00:03.321',
+  end: '00:00:10.321'
 };
 const divItemWithChildren = {
   type: 'div',
@@ -74,8 +74,8 @@ const divItemWithChildren = {
           type: 'span',
           label: 'Segment 2.1',
           id: '123a-456b-789c-8d',
-          begin: '00:09:03.24',
-          end: '00:15:00.00'
+          begin: '00:09:03.241',
+          end: '00:15:00.001'
         }
       ]
     }

--- a/src/components/__tests__/ListItemEditForm.test.js
+++ b/src/components/__tests__/ListItemEditForm.test.js
@@ -51,8 +51,8 @@ test("ListItemEditForm renders TimespanInlineForm for item with type 'span'", ()
     type: 'span',
     label: 'Segment 1.2',
     id: '123a-456b-789c-4d',
-    begin: '00:00:11.23',
-    end: '00:08:00.00'
+    begin: '00:00:11.231',
+    end: '00:08:00.001'
   };
 
   const { getByTestId } = renderWithRedux(
@@ -70,8 +70,8 @@ test('clicking on cancel button calls the mock function for cancelling the form'
     type: 'span',
     label: 'Segment 1.2',
     id: '123a-456b-789c-4d',
-    begin: '00:00:11.23',
-    end: '00:08:00.00'
+    begin: '00:00:11.231',
+    end: '00:08:00.001'
   };
 
   const { getByTestId } = renderWithRedux(

--- a/src/components/__tests__/TimespanForm.test.js
+++ b/src/components/__tests__/TimespanForm.test.js
@@ -25,7 +25,7 @@ const initialState = {
     isDragging: false,
     segment: {
       startTime: 0,
-      endTime: 3.32,
+      endTime: 3.321,
       labelText: '',
       id: 'temp-segment',
       editable: true,
@@ -43,7 +43,7 @@ const cancelMock = jest.fn();
 const props = {
   initSegment: {
     startTime: 0,
-    endTime: 3.32,
+    endTime: 3.321,
     editable: true,
     color: '#FBB040',
     id: 'temp-segment'
@@ -76,8 +76,8 @@ test('initial render with default begin/end time and save button disabled', () =
   expect(getByTestId('timespan-form-save-button')).toBeDisabled();
 
   // Begin Time and End Time is filled with default values
-  expect(getAllByPlaceholderText('00:00:00')[0].value).toBe('00:00:00.00');
-  expect(getAllByPlaceholderText('00:00:00')[1].value).toBe('00:00:03.32');
+  expect(getAllByPlaceholderText('00:00:00')[0].value).toBe('00:00:00.000');
+  expect(getAllByPlaceholderText('00:00:00')[1].value).toBe('00:00:03.321');
 
   // Child Of options list is filled with valid headings
   const childOfSelect = container.querySelector('#timespanChildOf');
@@ -159,7 +159,7 @@ describe('shows proper validation messages for begin/end time changes and save b
 
     const endTimeInput = timespanForm.getByLabelText(/end time/i);
     fireEvent.change(endTimeInput, {
-      target: { value: '00:00:04.00' }
+      target: { value: '00:00:04.001' }
     });
 
     expect(
@@ -184,7 +184,7 @@ describe('shows proper validation messages for begin/end time changes and save b
 
     const beginTimeInput = timespanForm.getByLabelText(/begin time/i);
     fireEvent.change(beginTimeInput, {
-      target: { value: '00:00:05.00' }
+      target: { value: '00:00:05.001' }
     });
 
     expect(
@@ -233,8 +233,8 @@ describe('submitting the form', () => {
   });
   test('save the new timespan', () => {
     const expectedPayload = {
-      beginTime: '00:00:00.00',
-      endTime: '00:00:03.32',
+      beginTime: '00:00:00.000',
+      endTime: '00:00:03.321',
       timespanChildOf: '123a-456b-789c-2d',
       timespanTitle: 'New Timespan'
     };

--- a/src/components/__tests__/TimespanInlineForm.test.js
+++ b/src/components/__tests__/TimespanInlineForm.test.js
@@ -37,8 +37,8 @@ const props = {
     type: 'span',
     label: 'Segment 2.1',
     id: '123a-456b-789c-8d',
-    begin: '00:09:03.24',
-    end: '00:15:00.00'
+    begin: '00:09:03.241',
+    end: '00:15:00.001'
   },
   isTyping: false,
   isInitializing: true,
@@ -55,8 +55,8 @@ test('TimespanInlineForm renders with existing values', () => {
   );
   expect(getByTestId('timespan-inline-form')).toBeInTheDocument();
   expect(getByLabelText(/title/i).value).toBe('Segment 2.1');
-  expect(getByLabelText(/begin time/i).value).toBe('00:09:03.24');
-  expect(getByLabelText(/end time/i).value).toBe('00:15:00.00');
+  expect(getByLabelText(/begin time/i).value).toBe('00:09:03.241');
+  expect(getByLabelText(/end time/i).value).toBe('00:15:00.001');
 });
 
 test('timespan title input shows proper validation messages', () => {
@@ -100,7 +100,7 @@ test('shows proper validation messages for begin/end time changes and save butto
   expect(saveButton).toBeDisabled();
 
   fireEvent.change(beginTimeInput, {
-    target: { value: '00:09:00.00' }
+    target: { value: '00:09:00.001' }
   });
   expect(beginTimeForm.classList.contains('has-error')).toBeFalsy();
   expect(beginTimeForm.classList.contains('has-success')).toBeTruthy();
@@ -124,8 +124,8 @@ describe('form changes when segment in the waveform change', () => {
       peaksInstance: {
         peaks: Peaks.init(peaksOptions),
         segment: {
-          startTime: 450, // changed from 00:09:03.24 -> 00:07:30.00
-          endTime: 900,
+          startTime: 450.001, // changed from 00:09:03.241 -> 00:07:30.001
+          endTime: 900.001,
           labelText: 'Segment 2.1',
           id: '123a-456b-789c-8d',
           editable: true,
@@ -139,13 +139,13 @@ describe('form changes when segment in the waveform change', () => {
       nextState
     );
 
-    // expects begin value to be the last possible valid value: 00:08:00.00
+    // expects begin value to be the last possible valid value: 00:08:00.001
     expect(timespanInlineForm.getByLabelText(/begin time/i).value).toBe(
-      '00:08:00.00'
+      '00:08:00.001'
     );
     // end time does not change
     expect(timespanInlineForm.getByLabelText(/end time/i).value).toBe(
-      '00:15:00.00'
+      '00:15:00.001'
     );
     expect(saveButton).toBeEnabled();
   });
@@ -158,8 +158,8 @@ describe('form changes when segment in the waveform change', () => {
       peaksInstance: {
         peaks: Peaks.init(peaksOptions),
         segment: {
-          startTime: 540, // changed from 00:09:03.24 -> 00:09:00.00
-          endTime: 900,
+          startTime: 540.001, // changed from 00:09:03.241 -> 00:09:00.001
+          endTime: 900.001,
           labelText: 'Segment 2.1',
           id: '123a-456b-789c-8d',
           editable: true,
@@ -174,11 +174,11 @@ describe('form changes when segment in the waveform change', () => {
     );
 
     expect(timespanInlineForm.getByLabelText(/begin time/i).value).toBe(
-      '00:09:00.00'
+      '00:09:00.001'
     );
     // end time does not change
     expect(timespanInlineForm.getByLabelText(/end time/i).value).toBe(
-      '00:15:00.00'
+      '00:15:00.001'
     );
     expect(saveButton).toBeEnabled();
   });
@@ -192,14 +192,14 @@ describe('submit the inline timespan form', () => {
       { initialState }
     );
     fireEvent.change(timespanInlineForm.getByLabelText(/end time/i), {
-      target: { value: '00:10:00.00' }
+      target: { value: '00:10:00.001' }
     });
   });
   test('save the edited timespan', () => {
     fireEvent.click(timespanInlineForm.getByTestId('inline-form-save-button'));
     expect(saveFnMock).toHaveBeenCalledWith('123a-456b-789c-8d', {
-      beginTime: '00:09:03.24',
-      endTime: '00:10:00.00',
+      beginTime: '00:09:03.241',
+      endTime: '00:10:00.001',
       timespanTitle: 'Segment 2.1'
     });
     expect(saveFnMock).toHaveBeenCalledTimes(1);

--- a/src/data/mock-response-structure.json
+++ b/src/data/mock-response-structure.json
@@ -1,1 +1,64 @@
-{"type":"div","label":"j3860704z-utah_phillips_one_2018.mp3","items":[{"type":"div","label":"First segment","items":[{"type":"div","label":"Sub-Segment 1.1","items":[]},{"type":"span","label":"Segment 1.1","begin":"00:00:03.32","end":"00:00:10.32"},{"type":"span","label":"Segment 1.2","begin":"00:00:11.23","end":"00:09:03.23"}]},{"type":"div","label":"Second segment","items":[{"type":"div","label":"Sub-Segment 2.1","items":[{"type":"div","label":"Sub-Segment 2.1.1","items":[]},{"type":"span","label":"Segment 2.1","begin":"00:09:03.24","end":"00:15:00.00"}]}]},{"type":"div","label":"Excellent Third Segment Series","items":[{"type":"span","label":"Spannn","begin":"00:15:01.00","end":"00:21:00.00"}]}]}
+{
+    "type": "div",
+    "label": "j3860704z-utah_phillips_one_2018.mp3",
+    "items": [
+        {
+            "type": "div",
+            "label": "First segment",
+            "items": [
+                {
+                    "type": "div",
+                    "label": "Sub-Segment 1.1",
+                    "items": []
+                },
+                {
+                    "type": "span",
+                    "label": "Segment 1.1",
+                    "begin": "00:00:03.321",
+                    "end": "00:00:10.321"
+                },
+                {
+                    "type": "span",
+                    "label": "Segment 1.2",
+                    "begin": "00:00:11.231",
+                    "end": "00:09:03.231"
+                }
+            ]
+        },
+        {
+            "type": "div",
+            "label": "Second segment",
+            "items": [
+                {
+                    "type": "div",
+                    "label": "Sub-Segment 2.1",
+                    "items": [
+                        {
+                            "type": "div",
+                            "label": "Sub-Segment 2.1.1",
+                            "items": []
+                        },
+                        {
+                            "type": "span",
+                            "label": "Segment 2.1",
+                            "begin": "00:09:03.241",
+                            "end": "00:15:00.001"
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "type": "div",
+            "label": "Excellent Third Segment Series",
+            "items": [
+                {
+                    "type": "span",
+                    "label": "Spannn",
+                    "begin": "00:15:01.001",
+                    "end": "00:21:00.001"
+                }
+            ]
+        }
+    ]
+}

--- a/src/services/StructuralMetadataUtils.js
+++ b/src/services/StructuralMetadataUtils.js
@@ -71,9 +71,6 @@ export default class StructuralMetadataUtils {
     const regexMMSS = /^([0-9]*:[0-9]*.[0-9]*)$/i;
     const regexSS = /^([0-9]*.[0-9]*)$/i;
 
-    // Round duration to 2 decimal places
-    const fileLength = Math.round(duration / 10) / 100;
-
     // Convert time to HH:mm:ss.ms format to use in validation logic
     let convertToHHmmss = time => {
       if (regexMMSS.test(time)) {
@@ -97,7 +94,7 @@ export default class StructuralMetadataUtils {
           let endTime = convertToHHmmss(end);
           item.begin = this.toHHmmss(beginTime);
           if (beginTime > endTime) {
-            item.end = this.toHHmmss(fileLength);
+            item.end = this.toHHmmss(duration);
           } else {
             item.end = this.toHHmmss(endTime);
           }
@@ -807,7 +804,7 @@ export default class StructuralMetadataUtils {
 
     let hourStr = hours < 10 ? `0${hours}` : `${hours}`;
     let minStr = minutes < 10 ? `0${minutes}` : `${minutes}`;
-    let secStr = seconds.toFixed(2);
+    let secStr = seconds.toFixed(3);
     secStr = seconds < 10 ? `0${secStr}` : `${secStr}`;
 
     return `${hourStr}:${minStr}:${secStr}`;
@@ -819,7 +816,7 @@ export default class StructuralMetadataUtils {
     if (!decVal) {
       valueString = intVal;
     } else {
-      valueString = intVal + '.' + decVal.substring(0, 2);
+      valueString = intVal + '.' + decVal.substring(0, 3);
     }
     return parseFloat(valueString);
   }

--- a/src/services/StructuralMetadataUtils.test.js
+++ b/src/services/StructuralMetadataUtils.test.js
@@ -22,8 +22,8 @@ describe('StructuralMetadataUtils class', () => {
 
   test('creates a helper span object', () => {
     const obj = {
-      beginTime: '00:00:01',
-      endTime: '00:00:02',
+      beginTime: '00:00:011',
+      endTime: '00:00:021',
       timespanChildOf: '3bf42620-2321-11e9-aa56-f9563015e266',
       timespanTitle: 'Tester'
     };
@@ -31,8 +31,8 @@ describe('StructuralMetadataUtils class', () => {
 
     expect(value).toHaveProperty('id');
     expect(value).toHaveProperty('type', 'span');
-    expect(value).toHaveProperty('begin', '00:00:01');
-    expect(value).toHaveProperty('end', '00:00:02');
+    expect(value).toHaveProperty('begin', '00:00:011');
+    expect(value).toHaveProperty('end', '00:00:021');
     expect(value).toHaveProperty('label', 'Tester');
   });
 
@@ -50,8 +50,8 @@ describe('StructuralMetadataUtils class', () => {
         type: 'span',
         label: 'Segment 1.1',
         id: '123a-456b-789c-3d',
-        begin: '00:00:03.32',
-        end: '00:00:10.32'
+        begin: '00:00:03.321',
+        end: '00:00:10.321'
       });
     });
     test('deletes a header with children', () => {
@@ -70,15 +70,15 @@ describe('StructuralMetadataUtils class', () => {
             type: 'span',
             label: 'Segment 1.1',
             id: '123a-456b-789c-3d',
-            begin: '00:00:03.32',
-            end: '00:00:10.32'
+            begin: '00:00:03.321',
+            end: '00:00:10.321'
           },
           {
             type: 'span',
             label: 'Segment 1.2',
             id: '123a-456b-789c-4d',
-            begin: '00:00:11.23',
-            end: '00:08:00.00'
+            begin: '00:00:11.231',
+            end: '00:08:00.001'
           }
         ]
       };
@@ -104,8 +104,8 @@ describe('StructuralMetadataUtils class', () => {
         type: 'span',
         label: 'Segment 2.1',
         id: '123a-456b-789c-8d',
-        begin: '00:09:03.24',
-        end: '00:15:00.00'
+        begin: '00:09:03.241',
+        end: '00:15:00.001'
       });
     });
   });
@@ -115,24 +115,24 @@ describe('StructuralMetadataUtils class', () => {
     beforeEach(() => {
       allSpans = smu.getItemsOfType('span', testData);
     });
-    test('time == 00:00:00.00 (before the first timespan)', () => {
-      const time = '00:00:00.00';
+    test('time == 00:00:00.000 (before the first timespan)', () => {
+      const time = '00:00:00.000';
       expect(smu.doesTimeOverlap(time, allSpans)).toBeTruthy();
     });
-    test('time = 00:00:03.32 (start of the first timespan)', () => {
-      const time = '00:00:03.32';
+    test('time = 00:00:03.321 (start of the first timespan)', () => {
+      const time = '00:00:03.321';
       expect(smu.doesTimeOverlap(time, allSpans)).toBeTruthy();
     });
-    test('time == 00:00:05.00 (within an existing timespan)', () => {
-      const time = '00:00:05.00';
+    test('time == 00:00:05.001 (within an existing timespan)', () => {
+      const time = '00:00:05.001';
       expect(smu.doesTimeOverlap(time, allSpans)).toBeFalsy();
     });
-    test('time == 00:00:10.45 (between existing timespans)', () => {
-      const time = '00:00:10.45';
+    test('time == 00:00:10.451 (between existing timespans)', () => {
+      const time = '00:00:10.451';
       expect(smu.doesTimeOverlap(time, allSpans)).toBeTruthy();
     });
-    test('time == 00:15.00.00 (end of the last timespan)', () => {
-      const time = '00:15.00.00';
+    test('time == 00:15:00.001 (end of the last timespan)', () => {
+      const time = '00:15:00.001';
       expect(smu.doesTimeOverlap(time, allSpans)).toBeTruthy();
     });
   });
@@ -144,16 +144,16 @@ describe('StructuralMetadataUtils class', () => {
     });
     test('timespan overlapping an existing timespan', () => {
       const value = smu.doesTimespanOverlap(
-        '00:00:00.00',
-        '00:00:05.00',
+        '00:00:00.000',
+        '00:00:05.001',
         allSpans
       );
       expect(value).toBeTruthy();
     });
     test('timespan not overlapping an existing timespan', () => {
       const value = smu.doesTimespanOverlap(
-        '00:15:00.00',
-        '00:18:00.00',
+        '00:15:00.001',
+        '00:18:00.001',
         allSpans
       );
       expect(value).toBeFalsy();
@@ -178,16 +178,16 @@ describe('StructuralMetadataUtils class', () => {
     });
     test('before first timespan', () => {
       const obj = {
-        begin: '00:00:00.00',
-        end: '00:00:03.32'
+        begin: '00:00:00.000',
+        end: '00:00:03.321'
       };
       const expected = {
         before: null,
         after: {
           type: 'span',
           label: 'Segment 1.1',
-          begin: '00:00:03.32',
-          end: '00:00:10.32',
+          begin: '00:00:03.321',
+          end: '00:00:10.321',
           id: '123a-456b-789c-3d'
         }
       };
@@ -196,23 +196,23 @@ describe('StructuralMetadataUtils class', () => {
     });
     test('in between existing timespans', () => {
       const obj = {
-        begin: '00:00:10.32',
-        end: '00:00:11.23'
+        begin: '00:00:10.321',
+        end: '00:00:11.231'
       };
       const expected = {
         before: {
           type: 'span',
           label: 'Segment 1.1',
-          begin: '00:00:03.32',
-          end: '00:00:10.32',
+          begin: '00:00:03.321',
+          end: '00:00:10.321',
           id: '123a-456b-789c-3d'
         },
         after: {
           type: 'span',
           label: 'Segment 1.2',
           id: '123a-456b-789c-4d',
-          begin: '00:00:11.23',
-          end: '00:08:00.00'
+          begin: '00:00:11.231',
+          end: '00:08:00.001'
         }
       };
       const value = smu.findWrapperSpans(obj, allSpans);
@@ -220,15 +220,15 @@ describe('StructuralMetadataUtils class', () => {
     });
     test('after last timespan', () => {
       const obj = {
-        begin: '00:15:00.00',
-        end: '00:20:00.00'
+        begin: '00:15:00.001',
+        end: '00:20:00.001'
       };
       const expected = {
         before: {
           type: 'span',
           label: 'Segment 2.1',
-          begin: '00:09:03.24',
-          end: '00:15:00.00',
+          begin: '00:09:03.241',
+          end: '00:15:00.001',
           id: '123a-456b-789c-8d'
         },
         after: null
@@ -249,8 +249,8 @@ describe('StructuralMetadataUtils class', () => {
             type: 'span',
             label: 'Act 1',
             id: '123a-456b-789c-3d',
-            begin: '00:10:00.00',
-            end: '00:15:00.00'
+            begin: '00:10:00.001',
+            end: '00:15:00.001'
           }
         ]
       };
@@ -276,8 +276,8 @@ describe('StructuralMetadataUtils class', () => {
             type: 'span',
             label: 'Act 1',
             id: '123a-456b-789c-2d',
-            begin: '00:00:00.00',
-            end: '00:09:00.00'
+            begin: '00:00:00.000',
+            end: '00:09:00.001'
           }
         ]
       };
@@ -343,22 +343,22 @@ describe('StructuralMetadataUtils class', () => {
           type: 'span',
           label: 'Segment 1.1',
           id: '123a-456b-789c-3d',
-          begin: '00:00:03.32',
-          end: '00:00:10.32'
+          begin: '00:00:03.321',
+          end: '00:00:10.321'
         },
         {
           type: 'span',
           label: 'Segment 1.2',
           id: '123a-456b-789c-4d',
-          begin: '00:00:11.23',
-          end: '00:08:00.00'
+          begin: '00:00:11.231',
+          end: '00:08:00.001'
         },
         {
           type: 'span',
           label: 'Segment 2.1',
           id: '123a-456b-789c-8d',
-          begin: '00:09:03.24',
-          end: '00:15:00.00'
+          begin: '00:09:03.241',
+          end: '00:15:00.001'
         }
       ];
       const value = smu.getItemsOfType('span', testData);
@@ -367,8 +367,8 @@ describe('StructuralMetadataUtils class', () => {
         type: 'span',
         label: 'Segment 2.1',
         id: '123a-456b-789c-8d',
-        begin: '00:09:03.24',
-        end: '00:15:00.00'
+        begin: '00:09:03.241',
+        end: '00:15:00.001'
       });
     });
   });
@@ -379,8 +379,8 @@ describe('StructuralMetadataUtils class', () => {
         type: 'span',
         label: 'Segment 1.2',
         id: '123a-456b-789c-4d',
-        begin: '00:00:11.23',
-        end: '00:08:00.00'
+        begin: '00:00:11.231',
+        end: '00:08:00.001'
       };
       const expected = {
         type: 'div',
@@ -397,15 +397,15 @@ describe('StructuralMetadataUtils class', () => {
             type: 'span',
             label: 'Segment 1.1',
             id: '123a-456b-789c-3d',
-            begin: '00:00:03.32',
-            end: '00:00:10.32'
+            begin: '00:00:03.321',
+            end: '00:00:10.321'
           },
           {
             type: 'span',
             label: 'Segment 1.2',
             id: '123a-456b-789c-4d',
-            begin: '00:00:11.23',
-            end: '00:08:00.00'
+            begin: '00:00:11.231',
+            end: '00:08:00.001'
           }
         ]
       };
@@ -434,8 +434,8 @@ describe('StructuralMetadataUtils class', () => {
             type: 'span',
             label: 'Segment 2.1',
             id: '123a-456b-789c-8d',
-            begin: '00:09:03.24',
-            end: '00:15:00.00'
+            begin: '00:09:03.241',
+            end: '00:15:00.001'
           }
         ]
       };
@@ -446,7 +446,7 @@ describe('StructuralMetadataUtils class', () => {
 
   describe('finds valid headings when adding/editing a timespan', () => {
     test('no existing timespans', () => {
-      const newSpan = { begin: '00:00:00.01', end: '00:02:00.00' };
+      const newSpan = { begin: '00:00:00.011', end: '00:02:00.001' };
       const wrapperSpans = {
         before: null,
         after: null
@@ -498,21 +498,21 @@ describe('StructuralMetadataUtils class', () => {
       });
     });
     test('wrapped by existing timespans', () => {
-      const newSpan = { begin: '00:08:00.00', end: '00:09:00.00' };
+      const newSpan = { begin: '00:08:00.001', end: '00:09:00.001' };
       const wrapperSpans = {
         before: {
           type: 'span',
           label: 'Segment 1.2',
           id: '123a-456b-789c-4d',
-          begin: '00:00:11.23',
-          end: '00:08:00.00'
+          begin: '00:00:11.231',
+          end: '00:08:00.001'
         },
         after: {
           type: 'span',
           label: 'Segment 2.1',
           id: '123a-456b-789c-8d',
-          begin: '00:09:03.24',
-          end: '00:15:00.00'
+          begin: '00:09:03.241',
+          end: '00:15:00.001'
         }
       };
       const expected = [
@@ -546,14 +546,14 @@ describe('StructuralMetadataUtils class', () => {
       });
     });
     test('no wrapping timespans after', () => {
-      const newSpan = { begin: '00:15:00.00', end: '00:16:00.00' };
+      const newSpan = { begin: '00:15:00.001', end: '00:16:00.001' };
       const wrapperSpans = {
         before: {
           type: 'span',
           label: 'Segment 2.1',
           id: '123a-456b-789c-8d',
-          begin: '00:09:03.24',
-          end: '00:15:00.00'
+          begin: '00:09:03.241',
+          end: '00:15:00.001'
         },
         after: null
       };
@@ -583,15 +583,15 @@ describe('StructuralMetadataUtils class', () => {
       });
     });
     test('no wrapping span before', () => {
-      const newSpan = { begin: '00:00:00.00', end: '00:00:03.32' };
+      const newSpan = { begin: '00:00:00.000', end: '00:00:03.321' };
       const wrapperSpans = {
         before: null,
         after: {
           type: 'span',
           label: 'Act 1',
           id: '123a-456b-789c-3d',
-          begin: '00:00:03.32',
-          end: '00:00:10.32'
+          begin: '00:00:03.321',
+          end: '00:00:10.321'
         }
       };
       const expected = [
@@ -623,20 +623,20 @@ describe('StructuralMetadataUtils class', () => {
 
   describe('validates order of begin and end times', () => {
     test('begin time < end time', () => {
-      const begin = '00:00:10.30';
-      const end = '00:10:00.30';
+      const begin = '00:00:10.301';
+      const end = '00:10:00.301';
       const value = smu.validateBeforeEndTimeOrder(begin, end);
       expect(value).toBeTruthy();
     });
     test('begin time === end time', () => {
-      const begin = '00:00:10.30';
-      const end = '00:00:10.30';
+      const begin = '00:00:10.301';
+      const end = '00:00:10.301';
       const value = smu.validateBeforeEndTimeOrder(begin, end);
       expect(value).toBeFalsy();
     });
     test('begin time > end time', () => {
-      const begin = '00:10:00.30';
-      const end = '00:00:10.30';
+      const begin = '00:10:00.301';
+      const end = '00:00:10.301';
       const value = smu.validateBeforeEndTimeOrder(begin, end);
       expect(value).toBeFalsy();
     });
@@ -644,19 +644,19 @@ describe('StructuralMetadataUtils class', () => {
 
   describe('converts time in seconds to string hh:mm:ss.ss format', () => {
     test('when time is an integer', () => {
-      const timeInSeconds = 540.0;
+      const timeInSeconds = 540.001;
       const value = smu.toHHmmss(timeInSeconds);
-      expect(value).toEqual('00:09:00.00');
+      expect(value).toEqual('00:09:00.001');
     });
     test('when there are decimal points', () => {
       const timeInSeconds = 543.9983255;
       const value = smu.toHHmmss(timeInSeconds);
-      expect(value).toEqual('00:09:03.99');
+      expect(value).toEqual('00:09:03.998');
     });
     test('when decimal with zero at the end', () => {
-      const timeInSeconds = 545.2;
+      const timeInSeconds = 545.201;
       const value = smu.toHHmmss(timeInSeconds);
-      expect(value).toEqual('00:09:05.20');
+      expect(value).toEqual('00:09:05.201');
     });
   });
 });

--- a/src/services/WaveformDataUtils.js
+++ b/src/services/WaveformDataUtils.js
@@ -55,7 +55,7 @@ export default class WaveformDataUtils {
         rangeBeginTime >= segment.startTime &&
         rangeBeginTime <= segment.endTime
       ) {
-        // rounds upto 2 decimal points for accuracy
+        // rounds upto 3 decimal points for accuracy
         rangeBeginTime = this.roundOff(segment.endTime);
       }
       return rangeBeginTime;
@@ -66,9 +66,9 @@ export default class WaveformDataUtils {
       rangeEndTime =
         fileEndTime < 60
           ? fileEndTime
-          : Math.round((rangeBeginTime + 60.0) * 100) / 100;
+          : Math.round((rangeBeginTime + 60.0) * 1000) / 1000;
     } else {
-      rangeEndTime = Math.round((rangeBeginTime + 60.0) * 100) / 100;
+      rangeEndTime = Math.round((rangeBeginTime + 60.0) * 1000) / 1000;
     }
 
     // Validate end time of the temporary segment
@@ -276,9 +276,9 @@ export default class WaveformDataUtils {
       }
       if (startTime > current.startTime && endTime < current.endTime) {
         segment.startTime = current.endTime;
-        segment.endTime = current.endTime + 0.01;
+        segment.endTime = current.endTime + 0.001;
       } else if (
-        duration - 0.01 <= endTime &&
+        duration - 0.001 <= endTime &&
         endTime <= duration &&
         after &&
         after.id === current.id
@@ -303,7 +303,7 @@ export default class WaveformDataUtils {
         segment.endTime =
           i < segmentIndex ? current.startTime : current.endTime;
       } else if (segment.startTime === segment.endTime) {
-        segment.endTime = segment.startTime + 0.01;
+        segment.endTime = segment.startTime + 0.001;
       } else if (endTime > duration) {
         segment.endTime = duration;
       }
@@ -364,7 +364,7 @@ export default class WaveformDataUtils {
     let [hours, minutes, seconds] = strTime.split(':');
     let hoursAndMins = parseInt(hours) * 3600 + parseInt(minutes) * 60;
     let secondsIn = seconds === '' ? 0.0 : parseFloat(seconds);
-    return hoursAndMins + secondsIn;
+    return Math.round((hoursAndMins + secondsIn) * 1000) / 1000;
   }
 
   sortSegments(peaksInstance, sortBy) {
@@ -379,7 +379,7 @@ export default class WaveformDataUtils {
     if (!decVal) {
       valueString = intVal;
     } else {
-      valueString = intVal + '.' + decVal.substring(0, 2);
+      valueString = intVal + '.' + decVal.substring(0, 3);
     }
     return parseFloat(valueString);
   }

--- a/src/services/WaveformDataUtils.test.js
+++ b/src/services/WaveformDataUtils.test.js
@@ -17,22 +17,22 @@ describe('WaveformDataUtils class', () => {
   test('initializes peaks segments with metadata structure', () => {
     const expected = [
       {
-        startTime: 3.32,
-        endTime: 10.32,
+        startTime: 3.321,
+        endTime: 10.321,
         labelText: 'Segment 1.1',
         id: '123a-456b-789c-3d',
         color: '#80A590'
       },
       {
-        startTime: 11.23,
-        endTime: 480,
+        startTime: 11.231,
+        endTime: 480.001,
         labelText: 'Segment 1.2',
         id: '123a-456b-789c-4d',
         color: '#2A5459'
       },
       {
-        startTime: 543.24,
-        endTime: 900,
+        startTime: 543.241,
+        endTime: 900.001,
         labelText: 'Segment 2.1',
         id: '123a-456b-789c-8d',
         color: '#80A590'
@@ -67,7 +67,7 @@ describe('WaveformDataUtils class', () => {
           expect.arrayContaining([
             expect.objectContaining({
               startTime: 0,
-              endTime: 3.32,
+              endTime: 3.321,
               id: 'temp-segment',
               color: '#FBB040',
               editable: true
@@ -77,81 +77,81 @@ describe('WaveformDataUtils class', () => {
         expect(value.player.getCurrentTime()).toEqual(0);
       });
       test('when current time is in between an existing segment', () => {
-        peaks.player.seek(450);
+        peaks.player.seek(450.001);
         const value = waveformUtils.insertTempSegment(peaks);
         expect(value.segments._segments).toEqual(
           expect.arrayContaining([
             expect.objectContaining({
-              startTime: 480.0,
-              endTime: 540.0,
+              startTime: 480.001,
+              endTime: 540.001,
               id: 'temp-segment',
               color: '#FBB040',
               editable: true
             })
           ])
         );
-        expect(value.player.getCurrentTime()).toEqual(480.0);
+        expect(value.player.getCurrentTime()).toEqual(480.001);
       });
 
       test('when current time is at the end time of an existing timespan', () => {
-        peaks.player.seek(480.0);
+        peaks.player.seek(480.001);
         const value = waveformUtils.insertTempSegment(peaks);
         expect(value.segments._segments).toEqual(
           expect.arrayContaining([
             expect.objectContaining({
-              startTime: 480.0,
-              endTime: 540.0,
+              startTime: 480.001,
+              endTime: 540.001,
               id: 'temp-segment',
               color: '#FBB040',
               editable: true
             })
           ])
         );
-        expect(value.player.getCurrentTime()).toEqual(480.0);
+        expect(value.player.getCurrentTime()).toEqual(480.001);
       });
 
       test('when current time is at the begin time of an existing timespan', () => {
-        peaks.player.seek(543.24);
+        peaks.player.seek(543.241);
         const value = waveformUtils.insertTempSegment(peaks);
         expect(value.segments._segments).toEqual(
           expect.arrayContaining([
             expect.objectContaining({
-              startTime: 900.0,
-              endTime: 960.0,
+              startTime: 900.001,
+              endTime: 960.001,
               id: 'temp-segment',
               color: '#FBB040',
               editable: true
             })
           ])
         );
-        expect(value.player.getCurrentTime()).toEqual(900.0);
+        expect(value.player.getCurrentTime()).toEqual(900.001);
       });
 
       test('when end time of temporary segment overlaps existing segment', () => {
-        peaks.player.seek(520);
+        peaks.player.seek(520.001);
         const value = waveformUtils.insertTempSegment(peaks);
         expect(value.segments._segments).toEqual(
           expect.arrayContaining([
             expect.objectContaining({
-              startTime: 520,
-              endTime: 543.24,
+              startTime: 520.001,
+              endTime: 543.241,
               id: 'temp-segment',
               color: '#FBB040',
               editable: true
             })
           ])
         );
-        expect(value.player.getCurrentTime()).toEqual(520);
+        expect(value.player.getCurrentTime()).toEqual(520.001);
       });
 
       test('when current playhead time + 60 > duration of the media file', () => {
-        peaks.player.seek(1680);
+        peaks.player.seek(1680.001);
         const value = waveformUtils.insertTempSegment(peaks);
         expect(value.segments._segments).toEqual(
           expect.arrayContaining([
             expect.objectContaining({
-              startTime: 1680,
-              endTime: 1738.94,
+              startTime: 1680.001,
+              endTime: 1738.945,
               id: 'temp-segment',
               color: '#FBB040',
               editable: true
@@ -162,19 +162,19 @@ describe('WaveformDataUtils class', () => {
 
       test('when there are multiple small segments with a length of less than 60 seconds', () => {
         peaks.segments.add({
-          startTime: 1690,
-          endTime: 1738.95,
+          startTime: 1690.001,
+          endTime: 1738.951,
           id: '123a-456b-789c-9d',
           color: '#2A5459',
           labelText: 'Test segment'
         });
-        peaks.player.seek(450);
+        peaks.player.seek(450.001);
         const value = waveformUtils.insertTempSegment(peaks);
         expect(value.segments._segments).toEqual(
           expect.arrayContaining([
             expect.objectContaining({
-              startTime: 480.0,
-              endTime: 540.0,
+              startTime: 480.001,
+              endTime: 540.001,
               id: 'temp-segment',
               color: '#FBB040',
               editable: true
@@ -190,8 +190,8 @@ describe('WaveformDataUtils class', () => {
           type: 'span',
           label: 'Segment 1.2',
           id: '123a-456b-789c-4d',
-          begin: '00:00:11.23',
-          end: '00:08:00.00'
+          begin: '00:00:11.231',
+          end: '00:08:00.001'
         };
         const value = waveformUtils.deleteSegments(item, peaks);
         expect(value.segments._segments).toHaveLength(2);
@@ -224,8 +224,8 @@ describe('WaveformDataUtils class', () => {
               type: 'span',
               label: 'Segment 2.1',
               id: '123a-456b-789c-8d',
-              begin: '00:09:03.24',
-              end: '00:15:00.00'
+              begin: '00:09:03.241',
+              end: '00:15:00.001'
             }
           ]
         };
@@ -245,8 +245,8 @@ describe('WaveformDataUtils class', () => {
     describe('rebuilds waveform', () => {
       test('when a segment is added in between existing segments', () => {
         peaks.segments.add({
-          startTime: 500,
-          endTime: 540,
+          startTime: 500.001,
+          endTime: 540.001,
           id: '123a-456b-789c-9d',
           labelText: 'Added segment'
         });
@@ -323,8 +323,8 @@ describe('WaveformDataUtils class', () => {
     test('saves changes to an existing segment', () => {
       const clonedSegment = peaks.segments.getSegment('123a-456b-789c-4d');
       const currentState = {
-        beginTime: '00:00:10.33',
-        endTime: '00:08:00.00',
+        beginTime: '00:00:10.331',
+        endTime: '00:08:00.001',
         clonedSegment
       };
       const value = waveformUtils.saveSegment(currentState, peaks);
@@ -333,8 +333,8 @@ describe('WaveformDataUtils class', () => {
       expect(segments).toEqual(
         expect.arrayContaining([
           expect.objectContaining({
-            startTime: 10.33,
-            endTime: 480,
+            startTime: 10.331,
+            endTime: 480.001,
             id: '123a-456b-789c-4d'
           })
         ])
@@ -345,22 +345,22 @@ describe('WaveformDataUtils class', () => {
       let segment;
       beforeEach(() => {
         segment = {
-          startTime: 11.23,
-          endTime: 480,
+          startTime: 11.231,
+          endTime: 480.001,
           id: '123a-456b-789c-4d',
           labelText: 'Segment 1.2',
           color: '#2A5459'
         };
       });
       test('start time = 00:03:', () => {
-        const currentState = { beginTime: '00:03:', endTime: '00:08:00.00' };
+        const currentState = { beginTime: '00:03:', endTime: '00:08:00.001' };
         const value = waveformUtils.updateSegment(segment, currentState, peaks);
         const segments = value.segments.getSegments();
         expect(segments).toHaveLength(3);
         expect(segments).toEqual(
           expect.arrayContaining([
             expect.objectContaining({
-              startTime: 180,
+              startTime: 180.000,
               id: '123a-456b-789c-4d'
             })
           ])
@@ -368,24 +368,24 @@ describe('WaveformDataUtils class', () => {
       });
 
       test('start time = 00:03:59', () => {
-        const currentState = { beginTime: '00:03:59', endTime: '00:08:00.00' };
+        const currentState = { beginTime: '00:03:59', endTime: '00:08:00.001' };
         const value = waveformUtils.updateSegment(segment, currentState, peaks);
         const segments = value.segments.getSegments();
         expect(segments).toHaveLength(3);
         expect(segments).toEqual(
           expect.arrayContaining([
             expect.objectContaining({
-              startTime: 239,
+              startTime: 239.000,
               id: '123a-456b-789c-4d'
             })
           ])
         );
       });
 
-      test('start time = 00:03:59.99', () => {
+      test('start time = 00:03:59.991', () => {
         const currentState = {
-          beginTime: '00:03:59.99',
-          endTime: '00:08:00.00'
+          beginTime: '00:03:59.991',
+          endTime: '00:08:00.001'
         };
         const value = waveformUtils.updateSegment(segment, currentState, peaks);
         const segments = value.segments.getSegments();
@@ -393,7 +393,7 @@ describe('WaveformDataUtils class', () => {
         expect(segments).toEqual(
           expect.arrayContaining([
             expect.objectContaining({
-              startTime: 239.99,
+              startTime: 239.991,
               id: '123a-456b-789c-4d'
             })
           ])
@@ -404,19 +404,19 @@ describe('WaveformDataUtils class', () => {
     describe('prevents overlapping with existing segments', () => {
       test('when start time of an editing segment overlaps segment before', () => {
         const testSegment = {
-          startTime: 480,
-          endTime: 500,
+          startTime: 480.001,
+          endTime: 500.001,
           editable: true,
           id: 'test-segment',
           color: '#FBB040'
         };
         peaks.segments.add(testSegment);
         // Change start time to overlap with previous segment
-        testSegment.startTime = 479;
+        testSegment.startTime = 479.001;
         const value = waveformUtils.validateSegment(testSegment, peaks);
         expect(value).toEqual({
-          startTime: 480.0,
-          endTime: 500,
+          startTime: 480.001,
+          endTime: 500.001,
           editable: true,
           id: 'test-segment',
           color: '#FBB040'
@@ -425,19 +425,19 @@ describe('WaveformDataUtils class', () => {
 
       test('when end time of an editing segment overlaps segment after', () => {
         const testSegment = {
-          startTime: 490.99,
-          endTime: 540,
+          startTime: 490.991,
+          endTime: 540.001,
           editable: true,
           id: 'test-segment',
           color: '#FBB040'
         };
         peaks.segments.add(testSegment);
         // Change end time to overlap with following segment
-        testSegment.endTime = 543.25;
+        testSegment.endTime = 543.251;
         const value = waveformUtils.validateSegment(testSegment, peaks);
         expect(value).toEqual({
-          startTime: 490.99,
-          endTime: 543.24,
+          startTime: 490.991,
+          endTime: 543.241,
           editable: true,
           id: 'test-segment',
           color: '#FBB040'
@@ -446,19 +446,19 @@ describe('WaveformDataUtils class', () => {
 
       test('when a segment does not overlap neighboring segments', () => {
         const testSegment = {
-          startTime: 499.99,
-          endTime: 529.99,
+          startTime: 499.991,
+          endTime: 529.991,
           editable: true,
           id: 'test-segment',
           color: '#FBB040'
         };
         peaks.segments.add(testSegment);
         // Change end time of the segment
-        testSegment.endTime = 540.99;
+        testSegment.endTime = 540.991;
         const value = waveformUtils.validateSegment(testSegment, peaks);
         expect(value).toEqual({
-          startTime: 499.99,
-          endTime: 540.99,
+          startTime: 499.991,
+          endTime: 540.991,
           editable: true,
           id: 'test-segment',
           color: '#FBB040'
@@ -467,19 +467,19 @@ describe('WaveformDataUtils class', () => {
 
       test('when a segment overlaps the end time of the media file', () => {
         const testSegment = {
-          startTime: 1200.99,
-          endTime: 1699.99,
+          startTime: 1200.991,
+          endTime: 1699.991,
           editable: true,
           id: 'test-segment',
           color: '#FBB040'
         };
         peaks.segments.add(testSegment);
         // Change the end time to exceed the end time of the media file
-        testSegment.endTime = 1740;
+        testSegment.endTime = 1740.001;
         const value = waveformUtils.validateSegment(testSegment, peaks);
         expect(value).toEqual({
-          startTime: 1200.99,
-          endTime: 1738.94,
+          startTime: 1200.991,
+          endTime: 1738.945,
           editable: true,
           id: 'test-segment',
           color: '#FBB040'
@@ -488,19 +488,19 @@ describe('WaveformDataUtils class', () => {
 
       test('when there is a segment going until the end of the file over an existing segment', () => {
         const testSegment = {
-          startTime: 540.0,
-          endTime: 1738.94,
+          startTime: 540.001,
+          endTime: 1738.945,
           editable: true,
           id: 'test-segment',
           color: '#FBB040'
         };
         peaks.segments.add(testSegment);
         // Change the start time of the segment
-        testSegment.startTime = 541.43;
+        testSegment.startTime = 541.431;
         const value = waveformUtils.validateSegment(testSegment, peaks);
         expect(value).toEqual({
-          startTime: 541.43,
-          endTime: 543.24,
+          startTime: 541.431,
+          endTime: 543.241,
           editable: true,
           id: 'test-segment',
           color: '#FBB040'

--- a/src/services/testing-helpers.js
+++ b/src/services/testing-helpers.js
@@ -60,15 +60,15 @@ export const testSmData = [
             type: 'span',
             label: 'Segment 1.1',
             id: '123a-456b-789c-3d',
-            begin: '00:00:03.32',
-            end: '00:00:10.32'
+            begin: '00:00:03.321',
+            end: '00:00:10.321'
           },
           {
             type: 'span',
             label: 'Segment 1.2',
             id: '123a-456b-789c-4d',
-            begin: '00:00:11.23',
-            end: '00:08:00.00'
+            begin: '00:00:11.231',
+            end: '00:08:00.001'
           }
         ]
       },
@@ -92,8 +92,8 @@ export const testSmData = [
                 type: 'span',
                 label: 'Segment 2.1',
                 id: '123a-456b-789c-8d',
-                begin: '00:09:03.24',
-                end: '00:15:00.00'
+                begin: '00:09:03.241',
+                end: '00:15:00.001'
               }
             ]
           }
@@ -130,8 +130,8 @@ export const testEmptyHeaderBefore = [
             type: 'span',
             label: 'Act 1',
             id: '123a-456b-789c-3d',
-            begin: '00:10:00.00',
-            end: '00:15:00.00'
+            begin: '00:10:00.001',
+            end: '00:15:00.001'
           }
         ]
       }
@@ -154,8 +154,8 @@ export const testEmptyHeaderAfter = [
             type: 'span',
             label: 'Act 1',
             id: '123a-456b-789c-2d',
-            begin: '00:00:00.00',
-            end: '00:09:00.00'
+            begin: '00:00:00.000',
+            end: '00:09:00.001'
           }
         ]
       },


### PR DESCRIPTION
Fixes #68.

This PR naively updates all tests to use thousandths of seconds and fixes a few functions so the tests pass.  I did a quick manual test of the standalone SME and everything looked good.  

Peaks.js is only using hundredths for the playhead and drag handles but I didn't know how to override a peaks function.  It looks like we just need to add a zero here: https://github.com/bbc/peaks.js/blob/9f37a10746366142da3bd5c74083f2251b3c0c7f/src/main/waveform/waveform.utils.js#L45