### PR TITLE
Block UI when loading

### DIFF
--- a/dist/App.css
+++ b/dist/App.css
@@ -62,32 +62,48 @@ section {
 }
 
 /* Loading spinner from https://github.com/avalonmediasystem/avalon/blob/develop/app/assets/stylesheets/avalon/_loading-spinner.scss*/
+/* Modified to block the background while loading */
 .loading-spinner {
-  display: inline-block;
-  width: 80px;
-  height: 80px;
+  width: 100%;
+  height: 100%;
   position: absolute;
   z-index: 10;
   left: 0;
   right: 0;
-  margin: auto;
+  top: 0;
+  bottom: 0;
+  background-color: rgba(220, 218, 218, 0.3);
 }
+
 .loading-spinner:after {
   content: ' ';
   display: block;
+  position: absolute;
   width: 64px;
   height: 64px;
-  margin: 8px;
+  left: 48%;
+  top: 40%;
   border-radius: 50%;
   border: 6px solid #80a590;
-  border-color: #80a590 transparent #80a590 transparent;
+  border-color:#80a590 transparent #80a590 transparent;
+  -webkit-animation: loading-spinner 1.2s linear infinite;
   animation: loading-spinner 1.2s linear infinite;
 }
+
 @keyframes loading-spinner {
   0% {
     transform: rotate(0deg);
   }
   100% {
     transform: rotate(360deg);
+  }
+}
+
+@-webkit-keyframes loading-spinner {
+  0% {
+    -webkit-transform: rotate(0deg);
+  }
+  100% {
+    -webkit-transform: rotate(360deg);
   }
 }

--- a/dist/components/ButtonSection.js
+++ b/dist/components/ButtonSection.js
@@ -186,14 +186,14 @@ function (_Component) {
         "data-testid": "add-heading-button",
         block: true,
         onClick: this.handleHeadingClick,
-        disabled: this.state.disabled && editingDisabled || streamInfo.streamMediaLoading
+        disabled: this.state.disabled && editingDisabled
       }, "Add a Heading")), _react["default"].createElement(_reactBootstrap.Col, {
         xs: 6
       }, _react["default"].createElement(_reactBootstrap.Button, {
         "data-testid": "add-timespan-button",
         block: true,
         onClick: this.handleTimeSpanClick,
-        disabled: this.state.disabled && editingDisabled || streamInfo.streamMediaError || streamInfo.streamMediaLoading
+        disabled: this.state.disabled && editingDisabled || streamInfo.streamMediaError
       }, "Add a Timespan"))), _react["default"].createElement(_reactBootstrap.Collapse, {
         "in": this.state.headingOpen
       }, _react["default"].createElement("div", {

--- a/src/App.css
+++ b/src/App.css
@@ -62,32 +62,48 @@ section {
 }
 
 /* Loading spinner from https://github.com/avalonmediasystem/avalon/blob/develop/app/assets/stylesheets/avalon/_loading-spinner.scss*/
+/* Modified to block the background while loading */
 .loading-spinner {
-  display: inline-block;
-  width: 80px;
-  height: 80px;
+  width: 100%;
+  height: 100%;
   position: absolute;
   z-index: 10;
   left: 0;
   right: 0;
-  margin: auto;
+  top: 0;
+  bottom: 0;
+  background-color: rgba(220, 218, 218, 0.3);
 }
+
 .loading-spinner:after {
   content: ' ';
   display: block;
+  position: absolute;
   width: 64px;
   height: 64px;
-  margin: 8px;
+  left: 48%;
+  top: 40%;
   border-radius: 50%;
   border: 6px solid #80a590;
-  border-color: #80a590 transparent #80a590 transparent;
+  border-color:#80a590 transparent #80a590 transparent;
+  -webkit-animation: loading-spinner 1.2s linear infinite;
   animation: loading-spinner 1.2s linear infinite;
 }
+
 @keyframes loading-spinner {
   0% {
     transform: rotate(0deg);
   }
   100% {
     transform: rotate(360deg);
+  }
+}
+
+@-webkit-keyframes loading-spinner {
+  0% {
+    -webkit-transform: rotate(0deg);
+  }
+  100% {
+    -webkit-transform: rotate(360deg);
   }
 }

--- a/src/components/ButtonSection.js
+++ b/src/components/ButtonSection.js
@@ -130,7 +130,7 @@ class ButtonSection extends Component {
               data-testid="add-heading-button"
               block
               onClick={this.handleHeadingClick}
-              disabled={(this.state.disabled && editingDisabled) || streamInfo.streamMediaLoading}
+              disabled={this.state.disabled && editingDisabled}
             >
               Add a Heading
             </Button>
@@ -140,10 +140,8 @@ class ButtonSection extends Component {
               data-testid="add-timespan-button"
               block
               onClick={this.handleTimeSpanClick}
-              disabled={
-                (this.state.disabled && editingDisabled) ||
-                (streamInfo.streamMediaError || streamInfo.streamMediaLoading)
-              }
+              disabled={(this.state.disabled && editingDisabled)
+                 || (streamInfo.streamMediaError)}
             >
               Add a Timespan
             </Button>


### PR DESCRIPTION
The user can edit and delete the existing structure while the derivative is fetched. And then save it back to the server. 
This PR contains a fix to block the UI while the media is fetched.