### PR TITLE
Change CSS class to avoid external style getting applied

### DIFF
--- a/dist/App.css
+++ b/dist/App.css
@@ -1,3 +1,10 @@
+.sme-container {
+  padding-right: 15px;
+  padding-left: 15px;
+  margin-right: auto;
+  margin-left: auto;
+}
+
 section {
   margin-bottom: 10px;
 }

--- a/dist/App.js
+++ b/dist/App.js
@@ -91,7 +91,7 @@ function (_Component) {
       return _react["default"].createElement(_reactDnd.DragDropContextProvider, {
         backend: _reactDndHtml5Backend["default"]
       }, _react["default"].createElement("div", {
-        className: "container"
+        className: "sme-container"
       }, _react["default"].createElement(_WaveformContainer["default"], (0, _extends2["default"])({}, this.props, {
         structureAlert: this.state.structureAlert
       })), _react["default"].createElement(_ButtonSection["default"], null), _react["default"].createElement(_StructureOutputContainer["default"], (0, _extends2["default"])({

--- a/src/App.css
+++ b/src/App.css
@@ -1,3 +1,10 @@
+.sme-container {
+  padding-right: 15px;
+  padding-left: 15px;
+  margin-right: auto;
+  margin-left: auto;
+}
+
 section {
   margin-bottom: 10px;
 }

--- a/src/App.js
+++ b/src/App.js
@@ -45,7 +45,7 @@ class App extends Component {
   render() {
     return (
       <DragDropContextProvider backend={HTML5Backend}>
-        <div className="container">
+        <div className="sme-container">
           <WaveformContainer
             {...this.props}
             structureAlert={this.state.structureAlert}


### PR DESCRIPTION
### Description

When structural metadata editor is opened in Avalon, for some screen widths the content overflows the modal.

![Screenshot from 2019-12-13 15-33-33](https://user-images.githubusercontent.com/1331659/70830415-25007480-1dbe-11ea-97ac-863f15efaad0.png)

This happens because all the components within SME are enclosed in a `<div>` with `class="container"`, which is used in Bootstrap for responsive design. When SME is added to Avalon the Bootstrap CSS in Avalon gets applied here causing the overflow.

### Done Looks Like

Content in the modal do not overflow.
![Screenshot from 2019-12-13 15-33-54](https://user-images.githubusercontent.com/1331659/70830772-f8992800-1dbe-11ea-9542-d646d5ff60a8.png)
