### PR TITLE
Add support for mm:ss.ms time format

### DIFF
--- a/dist/services/StructuralMetadataUtils.js
+++ b/dist/services/StructuralMetadataUtils.js
@@ -7,9 +7,9 @@ Object.defineProperty(exports, "__esModule", {
 });
 exports["default"] = void 0;
 
-var _objectWithoutProperties2 = _interopRequireDefault(require("@babel/runtime/helpers/objectWithoutProperties"));
-
 var _slicedToArray2 = _interopRequireDefault(require("@babel/runtime/helpers/slicedToArray"));
+
+var _objectWithoutProperties2 = _interopRequireDefault(require("@babel/runtime/helpers/objectWithoutProperties"));
 
 var _classCallCheck2 = _interopRequireDefault(require("@babel/runtime/helpers/classCallCheck"));
 
@@ -19,15 +19,11 @@ var _defineProperty2 = _interopRequireDefault(require("@babel/runtime/helpers/de
 
 var _lodash = require("lodash");
 
-var _moment = _interopRequireDefault(require("moment"));
-
 var _v = _interopRequireDefault(require("uuid/v1"));
 
 function ownKeys(object, enumerableOnly) { var keys = Object.keys(object); if (Object.getOwnPropertySymbols) { var symbols = Object.getOwnPropertySymbols(object); if (enumerableOnly) symbols = symbols.filter(function (sym) { return Object.getOwnPropertyDescriptor(object, sym).enumerable; }); keys.push.apply(keys, symbols); } return keys; }
 
 function _objectSpread(target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i] != null ? arguments[i] : {}; if (i % 2) { ownKeys(source, true).forEach(function (key) { (0, _defineProperty2["default"])(target, key, source[key]); }); } else if (Object.getOwnPropertyDescriptors) { Object.defineProperties(target, Object.getOwnPropertyDescriptors(source)); } else { ownKeys(source).forEach(function (key) { Object.defineProperty(target, key, Object.getOwnPropertyDescriptor(source, key)); }); } } return target; }
-
-// import { sanitizeLabel } from './form-helper';
 
 /**
  * Rules - https://github.com/avalonmediasystem/avalon/issues/3022
@@ -156,51 +152,17 @@ function () {
     value: function buildSMUI(allItems, duration) {
       var _this2 = this;
 
-      // Regex to match hh:mm:ss, mm:ss OR seconds(as a float)/minutes(as an int)
-      var regexHHMMSS = /^([0-9]*:[0-9]*:[0-9]*.[0-9]*)$/i;
-      var regexMMSS = /^([0-9]*:[0-9]*)$/i;
-      var regexSS = /^([0-9]*.[0-9]*)$/i; // Convert file duration to seconds
-
+      // Convert file duration to seconds
       var durationInSeconds = Math.round(duration / 10) / 100; // Convert time to HH:mm:ss.ms format to use in validation logic
 
       var convertToSeconds = function convertToSeconds(time) {
-        if (regexMMSS.test(time)) {
-          var _time$split = time.split(':'),
-              _time$split2 = (0, _slicedToArray2["default"])(_time$split, 2),
-              minutes = _time$split2[0],
-              seconds = _time$split2[1];
+        var timeSeconds = _this2.toMs(time) / 1000; // When time property is missing
 
-          var minutesInS = parseInt(minutes) * 60;
-          var secondsNum = seconds ? parseFloat(seconds) : 0.0;
-          return minutesInS + secondsNum;
-        } else if (regexHHMMSS.test(time)) {
-          var _time$split$reverse = time.split(':').reverse(),
-              _time$split$reverse2 = (0, _slicedToArray2["default"])(_time$split$reverse, 3),
-              _seconds = _time$split$reverse2[0],
-              _minutes = _time$split$reverse2[1],
-              hours = _time$split$reverse2[2];
-
-          var hoursInS = hours ? parseInt(hours) * 3600 : 0;
-
-          var _minutesInS = parseInt(_minutes) * 60;
-
-          var _secondsNum = _seconds === '' ? 0.0 : parseFloat(_seconds);
-
-          return hoursInS + _minutesInS + _secondsNum;
-        } else if (regexSS.test(time)) {
-          var _time$split3 = time.split('.'),
-              _time$split4 = (0, _slicedToArray2["default"])(_time$split3, 2),
-              _minutes2 = _time$split4[0],
-              _seconds2 = _time$split4[1];
-
-          var _minutesInS2 = parseInt(_minutes2) * 60;
-
-          var _secondsNum2 = _seconds2 ? parseFloat(_seconds2) : 0.0;
-
-          return _minutesInS2 + _secondsNum2;
+        if (isNaN(timeSeconds)) {
+          return 0;
+        } else {
+          return timeSeconds;
         }
-
-        return _this2.toMs(time) / 1000;
       };
 
       var decodeHTML = function decodeHTML(lableText) {
@@ -1015,14 +977,24 @@ function () {
       }
     }
     /**
-     * Moment.js helper millisecond converter to make calculations consistent
+     * Convert hh:mm:ss to milliseconds to make calculations consistent
      * @param {String} strTime form input value
      */
 
   }, {
     key: "toMs",
     value: function toMs(strTime) {
-      return _moment["default"].duration(strTime).asMilliseconds();
+      var _strTime$split$revers = strTime.split(':').reverse(),
+          _strTime$split$revers2 = (0, _slicedToArray2["default"])(_strTime$split$revers, 3),
+          seconds = _strTime$split$revers2[0],
+          minutes = _strTime$split$revers2[1],
+          hours = _strTime$split$revers2[2];
+
+      var hoursInS = hours ? parseInt(hours) * 3600 : 0;
+      var minutesInS = minutes ? parseInt(minutes) * 60 : 0;
+      var secondsNum = seconds === '' ? 0.0 : parseFloat(seconds);
+      var timeSeconds = hoursInS + minutesInS + secondsNum;
+      return timeSeconds * 1000;
     }
     /**
      * Convert seconds to string format hh:mm:ss.ms
@@ -1034,7 +1006,7 @@ function () {
     value: function toHHmmss(secTime) {
       var sec_num = this.roundOff(secTime);
       var hours = Math.floor(sec_num / 3600);
-      var minutes = Math.floor(sec_num / 60);
+      var minutes = Math.floor(sec_num % 3600 / 60);
       var seconds = sec_num - minutes * 60 - hours * 3600;
       var hourStr = hours < 10 ? "0".concat(hours) : "".concat(hours);
       var minStr = minutes < 10 ? "0".concat(minutes) : "".concat(minutes);

--- a/dist/services/WaveformDataUtils.js
+++ b/dist/services/WaveformDataUtils.js
@@ -15,12 +15,15 @@ var _classCallCheck2 = _interopRequireDefault(require("@babel/runtime/helpers/cl
 
 var _createClass2 = _interopRequireDefault(require("@babel/runtime/helpers/createClass"));
 
+var _StructuralMetadataUtils = _interopRequireDefault(require("./StructuralMetadataUtils"));
+
 function ownKeys(object, enumerableOnly) { var keys = Object.keys(object); if (Object.getOwnPropertySymbols) { var symbols = Object.getOwnPropertySymbols(object); if (enumerableOnly) symbols = symbols.filter(function (sym) { return Object.getOwnPropertyDescriptor(object, sym).enumerable; }); keys.push.apply(keys, symbols); } return keys; }
 
 function _objectSpread(target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i] != null ? arguments[i] : {}; if (i % 2) { ownKeys(source, true).forEach(function (key) { (0, _defineProperty2["default"])(target, key, source[key]); }); } else if (Object.getOwnPropertyDescriptors) { Object.defineProperties(target, Object.getOwnPropertyDescriptors(source)); } else { ownKeys(source).forEach(function (key) { Object.defineProperty(target, key, Object.getOwnPropertyDescriptor(source, key)); }); } } return target; }
 
 // Colors for segments from Avalon branding pallette
 var COLOR_PALETTE = ['#80A590', '#2A5459', '#FBB040'];
+var smu = new _StructuralMetadataUtils["default"]();
 
 var WaveformDataUtils =
 /*#__PURE__*/
@@ -279,8 +282,8 @@ function () {
           endTime = currentState.endTime,
           clonedSegment = currentState.clonedSegment;
       clonedSegment.update({
-        startTime: this.toMs(beginTime),
-        endTime: this.toMs(endTime)
+        startTime: smu.toMs(beginTime) / 1000,
+        endTime: smu.toMs(endTime) / 1000
       });
       return peaksInstance;
     }
@@ -322,8 +325,8 @@ function () {
     value: function updateSegment(segment, currentState, peaksInstance) {
       var beginTime = currentState.beginTime,
           endTime = currentState.endTime;
-      var beginSeconds = this.toMs(beginTime);
-      var endSeconds = this.toMs(endTime);
+      var beginSeconds = smu.toMs(beginTime) / 1000;
+      var endSeconds = smu.toMs(endTime) / 1000;
       var changeSegment = peaksInstance.segments.getSegment(segment.id);
 
       if (beginSeconds < segment.endTime && segment.startTime !== beginSeconds) {
@@ -358,12 +361,7 @@ function () {
 
       var _this$findWrapperSegm = this.findWrapperSegments(segment, allSegments),
           before = _this$findWrapperSegm.before,
-          after = _this$findWrapperSegm.after; // index of the segment in the arrays
-
-
-      var segmentIndex = allSegments.map(function (seg) {
-        return seg.id;
-      }).indexOf(segment.id);
+          after = _this$findWrapperSegm.after;
 
       for (var i = 0; i < allSegments.length; i++) {
         var current = allSegments[i];
@@ -377,14 +375,10 @@ function () {
           segment.endTime = current.endTime + 0.001;
         } else if (duration - 0.001 <= endTime && endTime <= duration && after && after.id === current.id) {
           segment.endTime = after.startTime;
-        } else if (before && before.id === current.id && startTime < before.endTime) {
-          segment.startTime = before.endTime;
-        } else if (after && after.id === current.id && endTime > after.startTime) {
-          segment.endTime = after.startTime;
         } else if (startTime > current.startTime && startTime < current.endTime) {
-          segment.startTime = i < segmentIndex ? current.endTime : current.startTime;
+          segment.startTime = current.endTime;
         } else if (endTime > current.startTime && endTime < current.endTime) {
-          segment.endTime = i < segmentIndex ? current.startTime : current.endTime;
+          segment.endTime = current.startTime;
         } else if (segment.startTime === segment.endTime) {
           segment.endTime = segment.startTime + 0.001;
         } else if (endTime > duration) {
@@ -407,8 +401,8 @@ function () {
           label = timespan.label,
           id = timespan.id;
       return {
-        startTime: this.toMs(begin),
-        endTime: this.toMs(end),
+        startTime: smu.toMs(begin) / 1000,
+        endTime: smu.toMs(end) / 1000,
         labelText: label,
         id: id
       };
@@ -453,19 +447,6 @@ function () {
     key: "isOdd",
     value: function isOdd(num) {
       return num % 2;
-    }
-  }, {
-    key: "toMs",
-    value: function toMs(strTime) {
-      var _strTime$split = strTime.split(':'),
-          _strTime$split2 = (0, _slicedToArray2["default"])(_strTime$split, 3),
-          hours = _strTime$split2[0],
-          minutes = _strTime$split2[1],
-          seconds = _strTime$split2[2];
-
-      var hoursAndMins = parseInt(hours) * 3600 + parseInt(minutes) * 60;
-      var secondsIn = seconds === '' ? 0.0 : parseFloat(seconds);
-      return Math.round((hoursAndMins + secondsIn) * 1000) / 1000;
     }
   }, {
     key: "sortSegments",

--- a/dist/services/__test__/StructuralMetadataUtils.test.js
+++ b/dist/services/__test__/StructuralMetadataUtils.test.js
@@ -116,14 +116,6 @@ describe('StructuralMetadataUtils class', () => {
     beforeEach(() => {
       structure = smu.buildSMUI(testDataFromServer, 1738945);
     });
-    test('when time is in mm.ss (15.30) format', () => {
-      const timespan = smu.findItem('123a-456b-789c-3d', structure);
-      expect(timespan.begin).toEqual('00:15:30.000');
-    });
-    test('when time is in integer (3) format', () => {
-      const timespan = smu.findItem('123a-456b-789c-1d', structure);
-      expect(timespan.begin).toEqual('00:03:00.000');
-    });
     test('when time is in hh:mm:ss (00:10:42) format', () => {
       const timespan = smu.findItem('123a-456b-789c-2d', structure);
       expect(timespan.begin).toEqual('00:10:42.000');
@@ -132,8 +124,28 @@ describe('StructuralMetadataUtils class', () => {
       const timespan = smu.findItem('123a-456b-789c-2d', structure);
       expect(timespan.end).toEqual('00:15:00.230');
     });
-    test('when end time exceeds (00:38:58.000) file duration (00:28:58.950)', () => {
+    test('when time is in mm:ss (15:30) format', () => {
       const timespan = smu.findItem('123a-456b-789c-3d', structure);
+      expect(timespan.begin).toEqual('00:15:30.000');
+    });
+    test('when time is in mm:ss.ms (16:00.23) format', () => {
+      const timespan = smu.findItem('123a-456b-789c-3d', structure);
+      expect(timespan.end).toEqual('00:16:00.230');
+    });
+    test('when time is in ss (42) format', () => {
+      const timespan = smu.findItem('123a-456b-789c-1d', structure);
+      expect(timespan.end).toEqual('00:00:42.000');
+    });
+    test('when time is in ss.ms (41.45) format', () => {
+      const timespan = smu.findItem('123a-456b-789c-1d', structure);
+      expect(timespan.begin).toEqual('00:00:41.450');
+    });
+    test('when end time exceeds (00:38:58.000) file duration (00:28:58.950)', () => {
+      const timespan = smu.findItem('123a-456b-789c-4d', structure);
+      expect(timespan.end).toEqual('00:28:58.950');
+    });
+    test('when end time is missing', () => {
+      const timespan = smu.findItem('123a-456b-789c-5d', structure);
       expect(timespan.end).toEqual('00:28:58.950');
     });
   });

--- a/dist/services/__test__/WaveformDataUtils.test.js
+++ b/dist/services/__test__/WaveformDataUtils.test.js
@@ -360,7 +360,7 @@ describe('WaveformDataUtils class', () => {
         expect(segments).toEqual(
           expect.arrayContaining([
             expect.objectContaining({
-              startTime: 180.000,
+              startTime: 180.0,
               id: '123a-456b-789c-4d'
             })
           ])
@@ -375,7 +375,7 @@ describe('WaveformDataUtils class', () => {
         expect(segments).toEqual(
           expect.arrayContaining([
             expect.objectContaining({
-              startTime: 239.000,
+              startTime: 239.0,
               id: '123a-456b-789c-4d'
             })
           ])
@@ -398,6 +398,58 @@ describe('WaveformDataUtils class', () => {
             })
           ])
         );
+      });
+    });
+
+    describe('find wrapping segments', () => {
+      let allSegments = [];
+      beforeEach(() => {
+        allSegments = peaks.segments.getSegments();
+      });
+      test('for first segment', () => {
+        const currentSegment = {
+          labelText: 'Segment 1.1',
+          id: '123a-456b-789c-3d',
+          startTime: 3.321,
+          endTime: 10.321
+        };
+        const { before, after } = waveformUtils.findWrapperSegments(
+          currentSegment,
+          allSegments,
+          1738.951
+        );
+        expect(before).toEqual(undefined);
+        expect(after.id).toEqual('123a-456b-789c-4d');
+      });
+      test('for middle segment', () => {
+        const currentSegment = {
+          labelText: 'Segment 1.2',
+          id: '123a-456b-789c-4d',
+          startTime: 11.231,
+          endTime: 480.001
+        };
+        const { before, after } = waveformUtils.findWrapperSegments(
+          currentSegment,
+          allSegments,
+          1738.951
+        );
+        expect(before.id).toEqual('123a-456b-789c-3d');
+        expect(after.id).toEqual('123a-456b-789c-8d');
+      });
+      test('for last segment', () => {
+        const currentSegment = {
+          labelText: 'Segment 2.1',
+          id: '123a-456b-789c-8d',
+          startTime: 543.241,
+          endTime: 900.001
+        };
+        const { before, after } = waveformUtils.findWrapperSegments(
+          currentSegment,
+          allSegments,
+          1738.951
+        );
+        expect(before.id).toEqual('123a-456b-789c-4d');
+        expect(after).toEqual(undefined);
       });
     });
 

--- a/dist/services/testing-helpers.js
+++ b/dist/services/testing-helpers.js
@@ -133,8 +133,8 @@ var testDataFromServer = [{
     type: 'span',
     label: 'First segment',
     id: '123a-456b-789c-1d',
-    begin: '3',
-    end: '10.42'
+    begin: '41.45',
+    end: '42'
   }, {
     type: 'span',
     label: 'Middle segment',
@@ -143,10 +143,22 @@ var testDataFromServer = [{
     end: '00:15:00.23'
   }, {
     type: 'span',
-    label: 'Final segment',
+    label: 'Segmet 1',
     id: '123a-456b-789c-3d',
     begin: '15:30',
+    end: '16:00.23'
+  }, {
+    type: 'span',
+    label: 'Segment 2',
+    id: '123a-456b-789c-4d',
+    begin: '16:30',
     end: '00:38:58'
+  }, {
+    type: 'span',
+    label: 'Final segment',
+    id: '123a-456b-789c-5d',
+    begin: '17:00',
+    end: 'NaN:NaN:NaN'
   }]
 }];
 exports.testDataFromServer = testDataFromServer;

--- a/package.json
+++ b/package.json
@@ -56,7 +56,6 @@
     "base-64": "^0.1.0",
     "hls.js": "0.12.3-canary.4258",
     "lodash": "4.17.13",
-    "moment": "^2.22.2",
     "peaks.js": "0.10.1",
     "prop-types": "^15.6.2",
     "react-bootstrap": "^0.32.4",

--- a/src/services/WaveformDataUtils.js
+++ b/src/services/WaveformDataUtils.js
@@ -1,5 +1,9 @@
+import StructuralMetadataUtils from './StructuralMetadataUtils';
+
 // Colors for segments from Avalon branding pallette
 const COLOR_PALETTE = ['#80A590', '#2A5459', '#FBB040'];
+
+const smu = new StructuralMetadataUtils();
 
 export default class WaveformDataUtils {
   /**
@@ -197,8 +201,8 @@ export default class WaveformDataUtils {
   saveSegment(currentState, peaksInstance) {
     const { beginTime, endTime, clonedSegment } = currentState;
     clonedSegment.update({
-      startTime: this.toMs(beginTime),
-      endTime: this.toMs(endTime)
+      startTime: smu.toMs(beginTime) / 1000,
+      endTime: smu.toMs(endTime) / 1000
     });
     return peaksInstance;
   }
@@ -237,8 +241,8 @@ export default class WaveformDataUtils {
    */
   updateSegment(segment, currentState, peaksInstance) {
     const { beginTime, endTime } = currentState;
-    let beginSeconds = this.toMs(beginTime);
-    let endSeconds = this.toMs(endTime);
+    let beginSeconds = smu.toMs(beginTime) / 1000;
+    let endSeconds = smu.toMs(endTime) / 1000;
     let changeSegment = peaksInstance.segments.getSegment(segment.id);
 
     if (beginSeconds < segment.endTime && segment.startTime !== beginSeconds) {
@@ -266,9 +270,6 @@ export default class WaveformDataUtils {
     // segments before and after the editing segment
     const { before, after } = this.findWrapperSegments(segment, allSegments);
 
-    // index of the segment in the arrays
-    const segmentIndex = allSegments.map(seg => seg.id).indexOf(segment.id);
-
     for (let i = 0; i < allSegments.length; i++) {
       const current = allSegments[i];
       if (current.id == segment.id) {
@@ -284,24 +285,10 @@ export default class WaveformDataUtils {
         after.id === current.id
       ) {
         segment.endTime = after.startTime;
-      } else if (
-        before &&
-        before.id === current.id &&
-        startTime < before.endTime
-      ) {
-        segment.startTime = before.endTime;
-      } else if (
-        after &&
-        after.id === current.id &&
-        endTime > after.startTime
-      ) {
-        segment.endTime = after.startTime;
       } else if (startTime > current.startTime && startTime < current.endTime) {
-        segment.startTime =
-          i < segmentIndex ? current.endTime : current.startTime;
+        segment.startTime = current.endTime;
       } else if (endTime > current.startTime && endTime < current.endTime) {
-        segment.endTime =
-          i < segmentIndex ? current.startTime : current.endTime;
+        segment.endTime = current.startTime;
       } else if (segment.startTime === segment.endTime) {
         segment.endTime = segment.startTime + 0.001;
       } else if (endTime > duration) {
@@ -318,8 +305,8 @@ export default class WaveformDataUtils {
   convertTimespanToSegment(timespan) {
     const { begin, end, label, id } = timespan;
     return {
-      startTime: this.toMs(begin),
-      endTime: this.toMs(end),
+      startTime: smu.toMs(begin) / 1000,
+      endTime: smu.toMs(end) / 1000,
       labelText: label,
       id: id
     };
@@ -358,13 +345,6 @@ export default class WaveformDataUtils {
 
   isOdd(num) {
     return num % 2;
-  }
-
-  toMs(strTime) {
-    let [hours, minutes, seconds] = strTime.split(':');
-    let hoursAndMins = parseInt(hours) * 3600 + parseInt(minutes) * 60;
-    let secondsIn = seconds === '' ? 0.0 : parseFloat(seconds);
-    return Math.round((hoursAndMins + secondsIn) * 1000) / 1000;
   }
 
   sortSegments(peaksInstance, sortBy) {

--- a/src/services/__test__/StructuralMetadataUtils.test.js
+++ b/src/services/__test__/StructuralMetadataUtils.test.js
@@ -116,14 +116,6 @@ describe('StructuralMetadataUtils class', () => {
     beforeEach(() => {
       structure = smu.buildSMUI(testDataFromServer, 1738945);
     });
-    test('when time is in mm.ss (15.30) format', () => {
-      const timespan = smu.findItem('123a-456b-789c-3d', structure);
-      expect(timespan.begin).toEqual('00:15:30.000');
-    });
-    test('when time is in integer (3) format', () => {
-      const timespan = smu.findItem('123a-456b-789c-1d', structure);
-      expect(timespan.begin).toEqual('00:03:00.000');
-    });
     test('when time is in hh:mm:ss (00:10:42) format', () => {
       const timespan = smu.findItem('123a-456b-789c-2d', structure);
       expect(timespan.begin).toEqual('00:10:42.000');
@@ -132,8 +124,28 @@ describe('StructuralMetadataUtils class', () => {
       const timespan = smu.findItem('123a-456b-789c-2d', structure);
       expect(timespan.end).toEqual('00:15:00.230');
     });
-    test('when end time exceeds (00:38:58.000) file duration (00:28:58.950)', () => {
+    test('when time is in mm:ss (15:30) format', () => {
       const timespan = smu.findItem('123a-456b-789c-3d', structure);
+      expect(timespan.begin).toEqual('00:15:30.000');
+    });
+    test('when time is in mm:ss.ms (16:00.23) format', () => {
+      const timespan = smu.findItem('123a-456b-789c-3d', structure);
+      expect(timespan.end).toEqual('00:16:00.230');
+    });
+    test('when time is in ss (42) format', () => {
+      const timespan = smu.findItem('123a-456b-789c-1d', structure);
+      expect(timespan.end).toEqual('00:00:42.000');
+    });
+    test('when time is in ss.ms (41.45) format', () => {
+      const timespan = smu.findItem('123a-456b-789c-1d', structure);
+      expect(timespan.begin).toEqual('00:00:41.450');
+    });
+    test('when end time exceeds (00:38:58.000) file duration (00:28:58.950)', () => {
+      const timespan = smu.findItem('123a-456b-789c-4d', structure);
+      expect(timespan.end).toEqual('00:28:58.950');
+    });
+    test('when end time is missing', () => {
+      const timespan = smu.findItem('123a-456b-789c-5d', structure);
       expect(timespan.end).toEqual('00:28:58.950');
     });
   });

--- a/src/services/__test__/WaveformDataUtils.test.js
+++ b/src/services/__test__/WaveformDataUtils.test.js
@@ -360,7 +360,7 @@ describe('WaveformDataUtils class', () => {
         expect(segments).toEqual(
           expect.arrayContaining([
             expect.objectContaining({
-              startTime: 180.000,
+              startTime: 180.0,
               id: '123a-456b-789c-4d'
             })
           ])
@@ -375,7 +375,7 @@ describe('WaveformDataUtils class', () => {
         expect(segments).toEqual(
           expect.arrayContaining([
             expect.objectContaining({
-              startTime: 239.000,
+              startTime: 239.0,
               id: '123a-456b-789c-4d'
             })
           ])
@@ -398,6 +398,58 @@ describe('WaveformDataUtils class', () => {
             })
           ])
         );
+      });
+    });
+
+    describe('find wrapping segments', () => {
+      let allSegments = [];
+      beforeEach(() => {
+        allSegments = peaks.segments.getSegments();
+      });
+      test('for first segment', () => {
+        const currentSegment = {
+          labelText: 'Segment 1.1',
+          id: '123a-456b-789c-3d',
+          startTime: 3.321,
+          endTime: 10.321
+        };
+        const { before, after } = waveformUtils.findWrapperSegments(
+          currentSegment,
+          allSegments,
+          1738.951
+        );
+        expect(before).toEqual(undefined);
+        expect(after.id).toEqual('123a-456b-789c-4d');
+      });
+      test('for middle segment', () => {
+        const currentSegment = {
+          labelText: 'Segment 1.2',
+          id: '123a-456b-789c-4d',
+          startTime: 11.231,
+          endTime: 480.001
+        };
+        const { before, after } = waveformUtils.findWrapperSegments(
+          currentSegment,
+          allSegments,
+          1738.951
+        );
+        expect(before.id).toEqual('123a-456b-789c-3d');
+        expect(after.id).toEqual('123a-456b-789c-8d');
+      });
+      test('for last segment', () => {
+        const currentSegment = {
+          labelText: 'Segment 2.1',
+          id: '123a-456b-789c-8d',
+          startTime: 543.241,
+          endTime: 900.001
+        };
+        const { before, after } = waveformUtils.findWrapperSegments(
+          currentSegment,
+          allSegments,
+          1738.951
+        );
+        expect(before.id).toEqual('123a-456b-789c-4d');
+        expect(after).toEqual(undefined);
       });
     });
 

--- a/src/services/testing-helpers.js
+++ b/src/services/testing-helpers.js
@@ -119,8 +119,8 @@ export const testDataFromServer = [
         type: 'span',
         label: 'First segment',
         id: '123a-456b-789c-1d',
-        begin: '3',
-        end: '10.42'
+        begin: '41.45',
+        end: '42'
       },
       {
         type: 'span',
@@ -131,10 +131,24 @@ export const testDataFromServer = [
       },
       {
         type: 'span',
-        label: 'Final segment',
+        label: 'Segmet 1',
         id: '123a-456b-789c-3d',
         begin: '15:30',
+        end: '16:00.23'
+      },
+      {
+        type: 'span',
+        label: 'Segment 2',
+        id: '123a-456b-789c-4d',
+        begin: '16:30',
         end: '00:38:58'
+      },
+      {
+        type: 'span',
+        label: 'Final segment',
+        id: '123a-456b-789c-5d',
+        begin: '17:00',
+        end: 'NaN:NaN:NaN'
       }
     ]
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5018,11 +5018,6 @@ mkdirp@^0.5.0, mkdirp@^0.5.1:
   dependencies:
     minimist "0.0.8"
 
-moment@^2.22.2:
-  version "2.24.0"
-  resolved "https://registry.yarnpkg.com/moment/-/moment-2.24.0.tgz#0d055d53f5052aa653c9f6eb68bb5d12bf5c2b5b"
-  integrity sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg==
-
 move-concurrently@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/move-concurrently/-/move-concurrently-1.0.1.tgz#be2c005fda32e0b29af1f05d7c4b33214c701f92"


### PR DESCRIPTION
Changes in this PR:
1. Support for hh:mm:ss(.ss), mm:ss(.ss), and ss(.ss) time formats
2. Removed moment.js dependency
3. Quick fix for timespan validation when dragging handles in waveform