### PR TITLE
Fix flashing error message on load

### DIFF
--- a/dist/actions/forms.js
+++ b/dist/actions/forms.js
@@ -115,9 +115,11 @@ function retrieveStreamMedia(audioFile, mediaPlayer) {
       }); // ERROR event is fired when fetching media stream is not successful
 
       hls.on(_hls["default"].Events.ERROR, function (event, data) {
-        var errorCode = null;
+        var errorCode = null; // When there are errors in the HLS build this block catches it and flashes
+        // the warning message for a split second. The ErrorType for these errors is
+        // OTHER_ERROR. Issue in HLS.js: https://github.com/video-dev/hls.js/issues/2435
 
-        if (data.fatal) {
+        if (data.fatal && data.type !== _hls["default"].ErrorTypes.OTHER_ERROR) {
           if (data.response !== undefined) {
             var status = data.response.code;
             status === 0 ? errorCode = -6 : errorCode = status;

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "@material-ui/icons": "4.2.1",
     "axios": "^0.19.0",
     "base-64": "^0.1.0",
-    "hls.js": "0.12.3-canary.4258",
+    "hls.js": "^0.13.3-canary.5556",
     "lodash": "4.17.13",
     "peaks.js": "^0.20.0",
     "prop-types": "^15.6.2",

--- a/src/actions/forms.js
+++ b/src/actions/forms.js
@@ -5,13 +5,13 @@ import Hls from 'hls.js';
  * Enable/disable other editing actions when editing a list item
  * @param {Integer} code - choose from; 1(true) | 0(false)
  */
-export const handleEditingTimespans = code => ({
+export const handleEditingTimespans = (code) => ({
   type: types.IS_EDITING_TIMESPAN,
-  code
+  code,
 });
 
 export const retrieveStructureSuccess = () => ({
-  type: types.RETRIEVE_STRUCTURE_SUCCESS
+  type: types.RETRIEVE_STRUCTURE_SUCCESS,
 });
 
 /**
@@ -19,13 +19,13 @@ export const retrieveStructureSuccess = () => ({
  * when an edit action is performed on the structure
  * @param {Integer} code - choose from; 1(true -> saved) | 0(false -> not saved)
  */
-export const updateStructureStatus = code => ({
+export const updateStructureStatus = (code) => ({
   type: types.UPDATE_STRUCTURE_STATUS,
-  payload: code
+  payload: code,
 });
 
 export const retrieveWaveformSuccess = () => ({
-  type: types.RETRIEVE_WAVEFORM_SUCCESS
+  type: types.RETRIEVE_WAVEFORM_SUCCESS,
 });
 
 /**
@@ -38,7 +38,7 @@ export const retrieveWaveformSuccess = () => ({
 export const handleStructureError = (flag, status) => ({
   type: types.HANDLE_STRUCTURE_ERROR,
   flag,
-  status
+  status,
 });
 
 /**
@@ -46,13 +46,13 @@ export const handleStructureError = (flag, status) => ({
  * of retries and still cannot load the stream media
  * @param {Integer} code - choose from; 1(true -> failed) | 0(false -> success)
  */
-export const streamMediaError = code => ({
+export const streamMediaError = (code) => ({
   type: types.STREAM_MEDIA_ERROR,
-  payload: code
+  payload: code,
 });
 
 export const streamMediaSuccess = () => ({
-  type: types.STREAM_MEDIA_SUCCESS
+  type: types.STREAM_MEDIA_SUCCESS,
 });
 
 export function retrieveStreamMedia(audioFile, mediaPlayer) {
@@ -63,18 +63,21 @@ export function retrieveStreamMedia(audioFile, mediaPlayer) {
       // Bind media player
       hls.attachMedia(mediaPlayer.current);
       // MEDIA_ATTACHED event is fired by hls object once MediaSource is ready
-      hls.on(Hls.Events.MEDIA_ATTACHED, function() {
+      hls.on(Hls.Events.MEDIA_ATTACHED, function () {
         hls.loadSource(audioFile);
         // BUFFER_CREATED event is fired when fetching the media stream is successful
-        hls.on(Hls.Events.BUFFER_CREATED, function() {
+        hls.on(Hls.Events.BUFFER_CREATED, function () {
           dispatch(streamMediaSuccess());
         });
       });
 
       // ERROR event is fired when fetching media stream is not successful
-      hls.on(Hls.Events.ERROR, function(event, data) {
+      hls.on(Hls.Events.ERROR, function (event, data) {
         let errorCode = null;
-        if (data.fatal) {
+        // When there are errors in the HLS build this block catches it and flashes
+        // the warning message for a split second. The ErrorType for these errors is
+        // OTHER_ERROR. Issue in HLS.js: https://github.com/video-dev/hls.js/issues/2435
+        if (data.fatal && data.type !== Hls.ErrorTypes.OTHER_ERROR) {
           if (data.response !== undefined) {
             const status = data.response.code;
             status === 0 ? (errorCode = -6) : (errorCode = status);

--- a/yarn.lock
+++ b/yarn.lock
@@ -2889,12 +2889,7 @@ eventemitter2@~6.3.1:
   resolved "https://registry.yarnpkg.com/eventemitter2/-/eventemitter2-6.3.1.tgz#14ec7db8c659aa9b36ad2ce4bfcaba95ad525536"
   integrity sha512-cxfu3g0IBn/JEhAPV33NZTi8llQQ5j62D0Yf4ir1U9uQ1DlRZLL3Hh2E/+TWDprSy4BETWvrGBZMUexuC2b6Lw==
 
-eventemitter3@3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-3.1.0.tgz#090b4d6cdbd645ed10bf750d4b5407942d7ba163"
-  integrity sha512-ivIvhpq/Y0uSjcHDcOIccjmYjGLcP09MFGE7ysAwkAvkXfpZlC985pH2/ui64DKazbTW/4kN3yqozUxlXzI6cA==
-
-eventemitter3@^4.0.0:
+eventemitter3@4.0.0, eventemitter3@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-4.0.0.tgz#d65176163887ee59f386d64c82610b696a4a74eb"
   integrity sha512-qerSRB0p+UDEssxTtm6EDKcE7W4OaoisfIMl4CngyEhjpYglocpNg6UEqCvemdGhosAsg4sO2dXJOdyBifPGCg==
@@ -3467,12 +3462,12 @@ he@1.2.x:
   resolved "https://registry.yarnpkg.com/he/-/he-1.2.0.tgz#84ae65fa7eafb165fddb61566ae14baf05664f0f"
   integrity sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==
 
-hls.js@0.12.3-canary.4258:
-  version "0.12.3-canary.4258"
-  resolved "https://registry.yarnpkg.com/hls.js/-/hls.js-0.12.3-canary.4258.tgz#9ef7e89a85609222497512b9baed806712246901"
-  integrity sha512-uSNt4fDVNb5rMpgMGjFvVaIqWwwRnIFiCrTY2zHCIQbaKgw8DOhA3QC5ImYdv8nXiZod5LS69dYxjnj/u8+3nw==
+hls.js@^0.13.3-canary.5556:
+  version "0.13.3-canary.5556"
+  resolved "https://registry.yarnpkg.com/hls.js/-/hls.js-0.13.3-canary.5556.tgz#061dc478ff9472c68c1c9c421c9b7cfa696169d6"
+  integrity sha512-7lzGB3Q0PSySlahRjF2imhoO9F0NvCCaTwpeEeSam8hFTVmC+STKwcqj+K5+C79hPJJXVwPICLHAtDdpG4IYDw==
   dependencies:
-    eventemitter3 "3.1.0"
+    eventemitter3 "4.0.0"
     url-toolkit "^2.1.6"
 
 hmac-drbg@^1.0.0:


### PR DESCRIPTION
The warning message flashes on load, because HLS error handling code in SME catches a uncaught error from HLS.js; `ReferenceError: o is not defined`

The respective issue for this in HLS repository is [here](https://github.com/video-dev/hls.js/issues/2435).

The HLS error type of this is `OTHER_ERROR`, therefore I have excluded errors with this type in the HLS error handling block in SME code. Even though this is not the ideal solution, we can keep it until HLS fixes this issue from their end.
This doesn't happen in the standalone application, because I think this reference issue is introduced when webpack builds HLS.