### PR TITLE
Fix bug in parent suggestions when adding a new timespan

### DIFF
--- a/dist/services/StructuralMetadataUtils.js
+++ b/dist/services/StructuralMetadataUtils.js
@@ -520,38 +520,40 @@ function () {
       var foundDiv = null;
 
       var findItem = function findItem(child, items) {
-        var _iteratorNormalCompletion4 = true;
-        var _didIteratorError4 = false;
-        var _iteratorError4 = undefined;
+        if (items && items.length > 0) {
+          var _iteratorNormalCompletion4 = true;
+          var _didIteratorError4 = false;
+          var _iteratorError4 = undefined;
 
-        try {
-          for (var _iterator4 = items[Symbol.iterator](), _step4; !(_iteratorNormalCompletion4 = (_step4 = _iterator4.next()).done); _iteratorNormalCompletion4 = true) {
-            var item = _step4.value;
-
-            if (item.items) {
-              var childItem = item.items.filter(function (currentChild) {
-                return child.id === currentChild.id;
-              }); // Found it
-
-              if (childItem.length > 0) {
-                foundDiv = item;
-                break;
-              }
-
-              findItem(child, item.items);
-            }
-          }
-        } catch (err) {
-          _didIteratorError4 = true;
-          _iteratorError4 = err;
-        } finally {
           try {
-            if (!_iteratorNormalCompletion4 && _iterator4["return"] != null) {
-              _iterator4["return"]();
+            for (var _iterator4 = items[Symbol.iterator](), _step4; !(_iteratorNormalCompletion4 = (_step4 = _iterator4.next()).done); _iteratorNormalCompletion4 = true) {
+              var item = _step4.value;
+
+              if (item.items) {
+                var childItem = item.items.filter(function (currentChild) {
+                  return child.id === currentChild.id;
+                }); // Found it
+
+                if (childItem.length > 0) {
+                  foundDiv = item;
+                  break;
+                }
+
+                findItem(child, item.items);
+              }
             }
+          } catch (err) {
+            _didIteratorError4 = true;
+            _iteratorError4 = err;
           } finally {
-            if (_didIteratorError4) {
-              throw _iteratorError4;
+            try {
+              if (!_iteratorNormalCompletion4 && _iterator4["return"] != null) {
+                _iterator4["return"]();
+              }
+            } finally {
+              if (_didIteratorError4) {
+                throw _iteratorError4;
+              }
             }
           }
         }
@@ -633,6 +635,10 @@ function () {
           divsAfter = wrapperParent.items.filter(function (item, i) {
             return i > spanIndex;
           });
+
+          var nextDivs = _this3.getItemsAfter(wrapperParent, allItems, []);
+
+          divsAfter = divsAfter.concat(nextDivs);
         } else {
           divsBefore = wrapperParent.items.filter(function (item, i) {
             return i < spanIndex;
@@ -709,6 +715,31 @@ function () {
         }
       });
       return uniqueHeadings;
+    }
+    /**
+     * Get items after a given item in the structure
+     * @param {Object} currentItem
+     * @param {Array} allItems all items in the structure
+     * @param {Array} nextDivs heading items after the current item
+     */
+
+  }, {
+    key: "getItemsAfter",
+    value: function getItemsAfter(currentItem, allItems, nextDivs) {
+      var parentItem = this.getParentDiv(currentItem, allItems);
+      var currentIndex = parentItem.items.map(function (item) {
+        return item.id;
+      }).indexOf(currentItem.id);
+      var nextItem = parentItem.items.filter(function (item, i) {
+        return i > currentIndex;
+      });
+      nextDivs = nextDivs.concat(nextItem);
+
+      if (this.getParentDiv(parentItem, allItems)) {
+        return this.getItemsAfter(parentItem, allItems, nextDivs);
+      }
+
+      return nextDivs;
     }
     /**
      * Helper function which handles React Dnd's dropping of a dragSource onto a dropTarget

--- a/dist/services/__test__/StructuralMetadataUtils.test.js
+++ b/dist/services/__test__/StructuralMetadataUtils.test.js
@@ -3,7 +3,7 @@ import {
   testSmData,
   testDataFromServer,
   testEmptyHeaderBefore,
-  testEmptyHeaderAfter
+  testEmptyHeaderAfter,
 } from '../testing-helpers';
 import { cloneDeep } from 'lodash';
 
@@ -26,7 +26,7 @@ describe('StructuralMetadataUtils class', () => {
       beginTime: '00:00:011',
       endTime: '00:00:021',
       timespanChildOf: '3bf42620-2321-11e9-aa56-f9563015e266',
-      timespanTitle: 'Tester'
+      timespanTitle: 'Tester',
     };
     const value = smu.createSpanObject(obj);
 
@@ -43,7 +43,7 @@ describe('StructuralMetadataUtils class', () => {
         type: 'div',
         label: 'Sub-Segment 1.1',
         id: '123a-456b-789c-2d',
-        items: []
+        items: [],
       };
       const value = smu.deleteListItem(obj.id, testData);
       expect(value).not.toContain(obj);
@@ -52,7 +52,7 @@ describe('StructuralMetadataUtils class', () => {
         label: 'Segment 1.1',
         id: '123a-456b-789c-3d',
         begin: '00:00:03.321',
-        end: '00:00:10.321'
+        end: '00:00:10.321',
       });
     });
     test('deletes a header with children', () => {
@@ -65,23 +65,23 @@ describe('StructuralMetadataUtils class', () => {
             type: 'div',
             label: 'Sub-Segment 1.1',
             id: '123a-456b-789c-2d',
-            items: []
+            items: [],
           },
           {
             type: 'span',
             label: 'Segment 1.1',
             id: '123a-456b-789c-3d',
             begin: '00:00:03.321',
-            end: '00:00:10.321'
+            end: '00:00:10.321',
           },
           {
             type: 'span',
             label: 'Segment 1.2',
             id: '123a-456b-789c-4d',
             begin: '00:00:11.231',
-            end: '00:08:00.001'
-          }
-        ]
+            end: '00:08:00.001',
+          },
+        ],
       };
       const value = smu.deleteListItem(obj.id, testData);
       expect(value).not.toContain(obj);
@@ -89,7 +89,7 @@ describe('StructuralMetadataUtils class', () => {
         type: 'div',
         label: 'Sub-Segment 2.1.1',
         id: '123a-456b-789c-7d',
-        items: []
+        items: [],
       });
     });
     test('deletes a childless header', () => {
@@ -97,7 +97,7 @@ describe('StructuralMetadataUtils class', () => {
         type: 'div',
         label: 'Sub-Segment 2.1.1',
         id: '123a-456b-789c-7d',
-        items: []
+        items: [],
       };
       const value = smu.deleteListItem(obj.id, testData);
       expect(value).not.toContain(obj);
@@ -106,7 +106,7 @@ describe('StructuralMetadataUtils class', () => {
         label: 'Segment 2.1',
         id: '123a-456b-789c-8d',
         begin: '00:09:03.241',
-        end: '00:15:00.001'
+        end: '00:15:00.001',
       });
     });
   });
@@ -205,7 +205,7 @@ describe('StructuralMetadataUtils class', () => {
       type: 'div',
       label: 'Sub-Segment 1.1',
       id: '123a-456b-789c-2d',
-      items: []
+      items: [],
     };
     const value = smu.findItem('123a-456b-789c-2d', testData);
     expect(value).toEqual(obj);
@@ -219,7 +219,7 @@ describe('StructuralMetadataUtils class', () => {
     test('before first timespan', () => {
       const obj = {
         begin: '00:00:00.000',
-        end: '00:00:03.321'
+        end: '00:00:03.321',
       };
       const expected = {
         before: null,
@@ -228,8 +228,8 @@ describe('StructuralMetadataUtils class', () => {
           label: 'Segment 1.1',
           begin: '00:00:03.321',
           end: '00:00:10.321',
-          id: '123a-456b-789c-3d'
-        }
+          id: '123a-456b-789c-3d',
+        },
       };
       const value = smu.findWrapperSpans(obj, allSpans);
       expect(value).toEqual(expected);
@@ -237,7 +237,7 @@ describe('StructuralMetadataUtils class', () => {
     test('in between existing timespans', () => {
       const obj = {
         begin: '00:00:10.321',
-        end: '00:00:11.231'
+        end: '00:00:11.231',
       };
       const expected = {
         before: {
@@ -245,15 +245,15 @@ describe('StructuralMetadataUtils class', () => {
           label: 'Segment 1.1',
           begin: '00:00:03.321',
           end: '00:00:10.321',
-          id: '123a-456b-789c-3d'
+          id: '123a-456b-789c-3d',
         },
         after: {
           type: 'span',
           label: 'Segment 1.2',
           id: '123a-456b-789c-4d',
           begin: '00:00:11.231',
-          end: '00:08:00.001'
-        }
+          end: '00:08:00.001',
+        },
       };
       const value = smu.findWrapperSpans(obj, allSpans);
       expect(value).toEqual(expected);
@@ -261,7 +261,7 @@ describe('StructuralMetadataUtils class', () => {
     test('after last timespan', () => {
       const obj = {
         begin: '00:15:00.001',
-        end: '00:20:00.001'
+        end: '00:20:00.001',
       };
       const expected = {
         before: {
@@ -269,9 +269,9 @@ describe('StructuralMetadataUtils class', () => {
           label: 'Segment 2.1',
           begin: '00:09:03.241',
           end: '00:15:00.001',
-          id: '123a-456b-789c-8d'
+          id: '123a-456b-789c-8d',
         },
-        after: null
+        after: null,
       };
       const value = smu.findWrapperSpans(obj, allSpans);
       expect(value).toEqual(expected);
@@ -290,9 +290,9 @@ describe('StructuralMetadataUtils class', () => {
             label: 'Act 1',
             id: '123a-456b-789c-3d',
             begin: '00:10:00.001',
-            end: '00:15:00.001'
-          }
-        ]
+            end: '00:15:00.001',
+          },
+        ],
       };
       const value = smu.findWrapperHeaders(obj, testEmptyHeaderBefore);
       const expected = {
@@ -300,9 +300,9 @@ describe('StructuralMetadataUtils class', () => {
           type: 'div',
           label: 'Scene 1',
           id: '123a-456b-789c-1d',
-          items: []
+          items: [],
         },
-        after: null
+        after: null,
       };
       expect(value).toEqual(expected);
     });
@@ -317,9 +317,9 @@ describe('StructuralMetadataUtils class', () => {
             label: 'Act 1',
             id: '123a-456b-789c-2d',
             begin: '00:00:00.000',
-            end: '00:09:00.001'
-          }
-        ]
+            end: '00:09:00.001',
+          },
+        ],
       };
       const value = smu.findWrapperHeaders(obj, testEmptyHeaderAfter);
       const expected = {
@@ -328,8 +328,8 @@ describe('StructuralMetadataUtils class', () => {
           type: 'div',
           label: 'Scene 2',
           id: '123a-456b-789c-3d',
-          items: []
-        }
+          items: [],
+        },
       };
       expect(value).toEqual(expected);
     });
@@ -341,40 +341,40 @@ describe('StructuralMetadataUtils class', () => {
         {
           type: 'div',
           label: 'Title',
-          id: '123a-456b-789c-0d'
+          id: '123a-456b-789c-0d',
         },
         {
           type: 'div',
           label: 'First segment',
-          id: '123a-456b-789c-1d'
+          id: '123a-456b-789c-1d',
         },
         {
           type: 'div',
           label: 'Sub-Segment 1.1',
-          id: '123a-456b-789c-2d'
+          id: '123a-456b-789c-2d',
         },
         {
           type: 'div',
           label: 'Second segment',
-          id: '123a-456b-789c-5d'
+          id: '123a-456b-789c-5d',
         },
         {
           type: 'div',
           label: 'Sub-Segment 2.1',
-          id: '123a-456b-789c-6d'
+          id: '123a-456b-789c-6d',
         },
         {
           type: 'div',
           label: 'Sub-Segment 2.1.1',
-          id: '123a-456b-789c-7d'
-        }
+          id: '123a-456b-789c-7d',
+        },
       ];
       const value = smu.getItemsOfType('div', testData);
       expect(value).toHaveLength(allDivs.length);
       expect(value).toContainEqual({
         type: 'div',
         label: 'Sub-Segment 2.1',
-        id: '123a-456b-789c-6d'
+        id: '123a-456b-789c-6d',
       });
     });
     test('type === span', () => {
@@ -384,22 +384,22 @@ describe('StructuralMetadataUtils class', () => {
           label: 'Segment 1.1',
           id: '123a-456b-789c-3d',
           begin: '00:00:03.321',
-          end: '00:00:10.321'
+          end: '00:00:10.321',
         },
         {
           type: 'span',
           label: 'Segment 1.2',
           id: '123a-456b-789c-4d',
           begin: '00:00:11.231',
-          end: '00:08:00.001'
+          end: '00:08:00.001',
         },
         {
           type: 'span',
           label: 'Segment 2.1',
           id: '123a-456b-789c-8d',
           begin: '00:09:03.241',
-          end: '00:15:00.001'
-        }
+          end: '00:15:00.001',
+        },
       ];
       const value = smu.getItemsOfType('span', testData);
       expect(value).toHaveLength(allSpans.length);
@@ -408,7 +408,7 @@ describe('StructuralMetadataUtils class', () => {
         label: 'Segment 2.1',
         id: '123a-456b-789c-8d',
         begin: '00:09:03.241',
-        end: '00:15:00.001'
+        end: '00:15:00.001',
       });
     });
   });
@@ -420,7 +420,7 @@ describe('StructuralMetadataUtils class', () => {
         label: 'Segment 1.2',
         id: '123a-456b-789c-4d',
         begin: '00:00:11.231',
-        end: '00:08:00.001'
+        end: '00:08:00.001',
       };
       const expected = {
         type: 'div',
@@ -431,23 +431,23 @@ describe('StructuralMetadataUtils class', () => {
             type: 'div',
             label: 'Sub-Segment 1.1',
             id: '123a-456b-789c-2d',
-            items: []
+            items: [],
           },
           {
             type: 'span',
             label: 'Segment 1.1',
             id: '123a-456b-789c-3d',
             begin: '00:00:03.321',
-            end: '00:00:10.321'
+            end: '00:00:10.321',
           },
           {
             type: 'span',
             label: 'Segment 1.2',
             id: '123a-456b-789c-4d',
             begin: '00:00:11.231',
-            end: '00:08:00.001'
-          }
-        ]
+            end: '00:08:00.001',
+          },
+        ],
       };
       const value = smu.getParentDiv(obj, testData);
       expect(value).toEqual(expected);
@@ -457,7 +457,7 @@ describe('StructuralMetadataUtils class', () => {
         type: 'div',
         label: 'Sub-Segment 2.1.1',
         id: '123a-456b-789c-7d',
-        items: []
+        items: [],
       };
       const expected = {
         type: 'div',
@@ -468,16 +468,16 @@ describe('StructuralMetadataUtils class', () => {
             type: 'div',
             label: 'Sub-Segment 2.1.1',
             id: '123a-456b-789c-7d',
-            items: []
+            items: [],
           },
           {
             type: 'span',
             label: 'Segment 2.1',
             id: '123a-456b-789c-8d',
             begin: '00:09:03.241',
-            end: '00:15:00.001'
-          }
-        ]
+            end: '00:15:00.001',
+          },
+        ],
       };
       const value = smu.getParentDiv(obj, testData);
       expect(value).toEqual(expected);
@@ -489,7 +489,7 @@ describe('StructuralMetadataUtils class', () => {
       const newSpan = { begin: '00:00:00.011', end: '00:02:00.001' };
       const wrapperSpans = {
         before: null,
-        after: null
+        after: null,
       };
       const structure = [
         {
@@ -501,40 +501,40 @@ describe('StructuralMetadataUtils class', () => {
               type: 'div',
               label: 'Scene 1',
               id: '123a-456b-789c-1d',
-              items: []
+              items: [],
             },
             {
               type: 'div',
               label: 'Scene 2',
               id: '123a-456b-789c-2d',
-              items: []
-            }
-          ]
-        }
+              items: [],
+            },
+          ],
+        },
       ];
       const expected = [
         {
           type: 'div',
           label: 'Title',
-          id: '123a-456b-789c-0d'
+          id: '123a-456b-789c-0d',
         },
         {
           type: 'div',
           label: 'Scene 1',
-          id: '123a-456b-789c-1d'
+          id: '123a-456b-789c-1d',
         },
         {
           type: 'div',
           label: 'Scene 2',
-          id: '123a-456b-789c-2d'
-        }
+          id: '123a-456b-789c-2d',
+        },
       ];
       const value = smu.getValidHeadings(newSpan, wrapperSpans, structure);
       expect(value).toHaveLength(expected.length);
       expect(value).toContainEqual({
         type: 'div',
         label: 'Scene 1',
-        id: '123a-456b-789c-1d'
+        id: '123a-456b-789c-1d',
       });
     });
     test('wrapped by existing timespans', () => {
@@ -545,44 +545,44 @@ describe('StructuralMetadataUtils class', () => {
           label: 'Segment 1.2',
           id: '123a-456b-789c-4d',
           begin: '00:00:11.231',
-          end: '00:08:00.001'
+          end: '00:08:00.001',
         },
         after: {
           type: 'span',
           label: 'Segment 2.1',
           id: '123a-456b-789c-8d',
           begin: '00:09:03.241',
-          end: '00:15:00.001'
-        }
+          end: '00:15:00.001',
+        },
       };
       const expected = [
         {
           type: 'div',
           label: 'First segment',
-          id: '123a-456b-789c-1d'
+          id: '123a-456b-789c-1d',
         },
         {
           type: 'div',
           label: 'Second segment',
-          id: '123a-456b-789c-5d'
+          id: '123a-456b-789c-5d',
         },
         {
           type: 'div',
           label: 'Sub-Segment 2.1',
-          id: '123a-456b-789c-6d'
+          id: '123a-456b-789c-6d',
         },
         {
           type: 'div',
           label: 'Sub-Segment 2.1.1',
-          id: '123a-456b-789c-7d'
-        }
+          id: '123a-456b-789c-7d',
+        },
       ];
       const value = smu.getValidHeadings(newSpan, wrapperSpans, testData);
       expect(value).toHaveLength(expected.length);
       expect(value).toContainEqual({
         type: 'div',
         label: 'Sub-Segment 2.1',
-        id: '123a-456b-789c-6d'
+        id: '123a-456b-789c-6d',
       });
     });
     test('no wrapping timespans after', () => {
@@ -593,33 +593,38 @@ describe('StructuralMetadataUtils class', () => {
           label: 'Segment 2.1',
           id: '123a-456b-789c-8d',
           begin: '00:09:03.241',
-          end: '00:15:00.001'
+          end: '00:15:00.001',
         },
-        after: null
+        after: null,
       };
       const expected = [
         {
           type: 'div',
           label: 'Title',
-          id: '123a-456b-789c-0d'
+          id: '123a-456b-789c-0d',
         },
         {
           type: 'div',
           label: 'Second segment',
-          id: '123a-456b-789c-5d'
+          id: '123a-456b-789c-5d',
         },
         {
           type: 'div',
           label: 'Sub-Segment 2.1',
-          id: '123a-456b-789c-6d'
-        }
+          id: '123a-456b-789c-6d',
+        },
+        {
+          type: 'div',
+          label: 'A ',
+          id: '123a-456b-789c-9d',
+        },
       ];
       const value = smu.getValidHeadings(newSpan, wrapperSpans, testData);
       expect(value).toHaveLength(expected.length);
       expect(value).toContainEqual({
         type: 'div',
         label: 'Sub-Segment 2.1',
-        id: '123a-456b-789c-6d'
+        id: '123a-456b-789c-6d',
       });
     });
     test('no wrapping span before', () => {
@@ -631,33 +636,124 @@ describe('StructuralMetadataUtils class', () => {
           label: 'Act 1',
           id: '123a-456b-789c-3d',
           begin: '00:00:03.321',
-          end: '00:00:10.321'
-        }
+          end: '00:00:10.321',
+        },
       };
       const expected = [
         {
           type: 'div',
           label: 'Title',
-          id: '123a-456b-789c-0d'
+          id: '123a-456b-789c-0d',
         },
         {
           type: 'div',
           label: 'First segment',
-          id: '123a-456b-789c-1d'
+          id: '123a-456b-789c-1d',
         },
         {
           type: 'div',
           label: 'Sub-Segment 1.1',
-          id: '123a-456b-789c-2d'
-        }
+          id: '123a-456b-789c-2d',
+        },
       ];
       const value = smu.getValidHeadings(newSpan, wrapperSpans, testData);
       expect(value).toHaveLength(expected.length);
       expect(value).toContainEqual({
         type: 'div',
         label: 'Sub-Segment 1.1',
-        id: '123a-456b-789c-2d'
+        id: '123a-456b-789c-2d',
       });
+    });
+  });
+
+  describe('get element after', () => {
+    test('a timespan in the middle of the structure', () => {
+      const expected = [
+        {
+          type: 'span',
+          label: 'Segment 1.2',
+          id: '123a-456b-789c-4d',
+          begin: '00:00:11.231',
+          end: '00:08:00.001',
+        },
+        {
+          type: 'div',
+          label: 'Second segment',
+          id: '123a-456b-789c-5d',
+          items: [
+            {
+              type: 'div',
+              label: 'Sub-Segment 2.1',
+              id: '123a-456b-789c-6d',
+              items: [
+                {
+                  type: 'div',
+                  label: 'Sub-Segment 2.1.1',
+                  id: '123a-456b-789c-7d',
+                  items: [],
+                },
+                {
+                  type: 'span',
+                  label: 'Segment 2.1',
+                  id: '123a-456b-789c-8d',
+                  begin: '00:09:03.241',
+                  end: '00:15:00.001',
+                },
+              ],
+            },
+          ],
+        },
+        {
+          type: 'div',
+          label: 'A ',
+          id: '123a-456b-789c-9d',
+          items: [],
+        },
+      ];
+      const currentItem = {
+        type: 'span',
+        label: 'Segment 1.1',
+        id: '123a-456b-789c-3d',
+        begin: '00:00:03.321',
+        end: '00:00:10.321',
+      };
+      const value = smu.getItemsAfter(currentItem, testData, []);
+      expect(value).toHaveLength(expected.length);
+      expect(value).toEqual(expected);
+    });
+
+    test('last leaf node in the structure', () => {
+      const currentItem = {
+        type: 'span',
+        label: 'Segment 2.1',
+        id: '123a-456b-789c-8d',
+        begin: '00:09:03.241',
+        end: '00:15:00.001',
+      };
+
+      const expected = [
+        {
+          type: 'div',
+          label: 'A ',
+          id: '123a-456b-789c-9d',
+          items: [],
+        },
+      ];
+      const value = smu.getItemsAfter(currentItem, testData, []);
+      expect(value).toHaveLength(expected.length);
+      expect(value).toEqual(expected);
+    });
+
+    test('last node in the structure', () => {
+      const currentItem = {
+        type: 'div',
+        label: 'A',
+        id: '123a-456b-789c-9d',
+        items: [],
+      };
+
+      const value = smu.getItemsAfter(currentItem, testData, []);
+      expect(value).toHaveLength(0);
     });
   });
 

--- a/src/services/StructuralMetadataUtils.js
+++ b/src/services/StructuralMetadataUtils.js
@@ -23,7 +23,7 @@ export default class StructuralMetadataUtils {
   createDropZoneObject() {
     return {
       type: 'optional',
-      id: uuidv1()
+      id: uuidv1(),
     };
   }
 
@@ -38,7 +38,7 @@ export default class StructuralMetadataUtils {
       type: 'span',
       label: obj.timespanTitle,
       begin: obj.beginTime,
-      end: obj.endTime
+      end: obj.endTime,
     };
   }
 
@@ -70,7 +70,7 @@ export default class StructuralMetadataUtils {
     const durationInSeconds = Math.round(duration / 10) / 100;
 
     // Convert time to HH:mm:ss.ms format to use in validation logic
-    let convertToSeconds = time => {
+    let convertToSeconds = (time) => {
       let timeSeconds = this.toMs(time) / 1000;
       // When time property is missing
       if (isNaN(timeSeconds)) {
@@ -80,7 +80,7 @@ export default class StructuralMetadataUtils {
       }
     };
 
-    let decodeHTML = lableText => {
+    let decodeHTML = (lableText) => {
       return lableText
         .replace(/&amp;/g, '&')
         .replace(/&lt;/g, '<')
@@ -90,7 +90,7 @@ export default class StructuralMetadataUtils {
     };
 
     // Recursive function to traverse whole data structure
-    let formatItems = items => {
+    let formatItems = (items) => {
       for (let item of items) {
         item.label = decodeHTML(item.label);
         if (item.type === 'span') {
@@ -133,7 +133,7 @@ export default class StructuralMetadataUtils {
       let parentDiv = this.getParentDiv(dragSource, clonedItems);
       let siblings = parentDiv ? parentDiv.items : [];
       let spanIndex = siblings
-        .map(sibling => sibling.id)
+        .map((sibling) => sibling.id)
         .indexOf(dragSource.id);
       let stuckInMiddle = this.dndHelper.stuckInMiddle(
         spanIndex,
@@ -175,11 +175,11 @@ export default class StructuralMetadataUtils {
       if (grandParentDiv !== null) {
         let siblingTimespans = this.getItemsOfType('span', siblings);
         let timespanIndex = siblingTimespans
-          .map(sibling => sibling.id)
+          .map((sibling) => sibling.id)
           .indexOf(dragSource.id);
 
         let parentIndex = grandParentDiv.items
-          .map(item => item.id)
+          .map((item) => item.id)
           .indexOf(parentDiv.id);
         if (timespanIndex === 0) {
           grandParentDiv.items.splice(
@@ -190,7 +190,7 @@ export default class StructuralMetadataUtils {
         }
         if (timespanIndex === siblingTimespans.length - 1) {
           let newPI = grandParentDiv.items
-            .map(item => item.id)
+            .map((item) => item.id)
             .indexOf(parentDiv.id);
           grandParentDiv.items.splice(
             newPI + 1,
@@ -230,7 +230,7 @@ export default class StructuralMetadataUtils {
       let beforeParent = this.getParentDiv(wrapperSpanBefore, allItems);
       let beforeSiblings = beforeParent.items;
       let beforeIndex = beforeSiblings
-        .map(item => item.id)
+        .map((item) => item.id)
         .indexOf(wrapperSpanBefore.id);
       // Before the insert, check that the dropTarget index doesn't already exist
       if (
@@ -245,7 +245,7 @@ export default class StructuralMetadataUtils {
       let afterParent = this.getParentDiv(wrapperSpanAfter, allItems);
       let afterSiblings = afterParent.items;
       let afterIndex = afterSiblings
-        .map(item => item.id)
+        .map((item) => item.id)
         .indexOf(wrapperSpanAfter.id);
       if (
         afterSiblings[afterIndex - 1] &&
@@ -275,7 +275,7 @@ export default class StructuralMetadataUtils {
           wrapperParents.after.items = [this.createDropZoneObject()];
         }
       }
-    }
+    },
   };
 
   /**
@@ -311,7 +311,7 @@ export default class StructuralMetadataUtils {
   doesTimespanOverlap(beginTime, endTime, allSpans) {
     const { toMs } = this;
     // Filter out only spans where new begin time is before an existing begin time
-    let filteredSpans = allSpans.filter(span => {
+    let filteredSpans = allSpans.filter((span) => {
       return toMs(beginTime) < toMs(span.begin);
     });
     // Return whether new end time overlaps the next begin time, if there are timespans after the current timespan
@@ -329,7 +329,7 @@ export default class StructuralMetadataUtils {
    */
   findItem(id, items) {
     let foundItem = null;
-    let fn = items => {
+    let fn = (items) => {
       for (let item of items) {
         if (item.id === id) {
           foundItem = item;
@@ -354,13 +354,13 @@ export default class StructuralMetadataUtils {
     const { toMs } = this;
     let wrapperSpans = {
       before: null,
-      after: null
+      after: null,
     };
     let spansBefore = allSpans.filter(
-      span => toMs(newSpan.begin) >= toMs(span.end)
+      (span) => toMs(newSpan.begin) >= toMs(span.end)
     );
     let spansAfter = allSpans.filter(
-      span => toMs(newSpan.end) <= toMs(span.begin)
+      (span) => toMs(newSpan.end) <= toMs(span.begin)
     );
 
     wrapperSpans.before =
@@ -378,16 +378,16 @@ export default class StructuralMetadataUtils {
   findWrapperHeaders(parentDiv, allItems) {
     const wrapperHeadings = {
       before: null,
-      after: null
+      after: null,
     };
     let grandParentDiv = this.getParentDiv(parentDiv, allItems);
     if (grandParentDiv != null) {
       let grandParentItems = grandParentDiv.items.filter(
-        item => item.type !== 'optional'
+        (item) => item.type !== 'optional'
       );
 
       let parentIndex = grandParentItems
-        .map(item => item.label)
+        .map((item) => item.label)
         .indexOf(parentDiv.label);
 
       wrapperHeadings.before =
@@ -411,7 +411,7 @@ export default class StructuralMetadataUtils {
     let options = [];
 
     // Recursive function to search the whole data structure
-    let getItems = items => {
+    let getItems = (items) => {
       for (let item of items) {
         if (item.type === type) {
           let currentObj = { ...item };
@@ -432,17 +432,19 @@ export default class StructuralMetadataUtils {
     let foundDiv = null;
 
     let findItem = (child, items) => {
-      for (let item of items) {
-        if (item.items) {
-          let childItem = item.items.filter(
-            currentChild => child.id === currentChild.id
-          );
-          // Found it
-          if (childItem.length > 0) {
-            foundDiv = item;
-            break;
+      if (items && items.length > 0) {
+        for (let item of items) {
+          if (item.items) {
+            let childItem = item.items.filter(
+              (currentChild) => child.id === currentChild.id
+            );
+            // Found it
+            if (childItem.length > 0) {
+              foundDiv = item;
+              break;
+            }
+            findItem(child, item.items);
           }
-          findItem(child, item.items);
         }
       }
     };
@@ -472,13 +474,13 @@ export default class StructuralMetadataUtils {
     );
 
     // Explore possible headings traversing outwards from a suggested heading
-    let exploreOutwards = heading => {
+    let exploreOutwards = (heading) => {
       let invalid = false;
       const parentHeading = this.getParentDiv(heading, allItems);
       const { begin: newBegin, end: newEnd } = newSpan;
       if (parentHeading && !stuckInMiddle) {
         const headingIndex = parentHeading.items
-          .map(item => item.id)
+          .map((item) => item.id)
           .indexOf(heading.id);
         const siblings = parentHeading.items;
         siblings.forEach((sibling, i) => {
@@ -504,12 +506,14 @@ export default class StructuralMetadataUtils {
     // Find relevant headings traversing into suggested headings
     let exploreInwards = (wrapperParent, wrapperSpan, isBefore) => {
       const spanIndex = wrapperParent.items
-        .map(item => item.id)
+        .map((item) => item.id)
         .indexOf(wrapperSpan.id);
       let divsAfter = [],
         divsBefore = [];
       if (isBefore) {
         divsAfter = wrapperParent.items.filter((item, i) => i > spanIndex);
+        const nextDivs = this.getItemsAfter(wrapperParent, allItems, []);
+        divsAfter = divsAfter.concat(nextDivs);
       } else {
         divsBefore = wrapperParent.items.filter((item, i) => i < spanIndex);
       }
@@ -545,12 +549,12 @@ export default class StructuralMetadataUtils {
       }
     }
 
-    allValidHeadings.map(heading => exploreOutwards(heading));
+    allValidHeadings.map((heading) => exploreOutwards(heading));
 
     // Sort valid headings to comply with the order in the metadata structure
-    allHeadings.forEach(key => {
+    allHeadings.forEach((key) => {
       let found = false;
-      allValidHeadings.filter(heading => {
+      allValidHeadings.filter((heading) => {
         if (!found && heading.label === key.label) {
           const { items, ...cloneWOItems } = heading;
           sortedHeadings.push(cloneWOItems);
@@ -563,8 +567,8 @@ export default class StructuralMetadataUtils {
     });
 
     // Filter the duplicated headings
-    sortedHeadings.map(heading => {
-      const indexIn = uniqueHeadings.map(h => h.id).indexOf(heading.id);
+    sortedHeadings.map((heading) => {
+      const indexIn = uniqueHeadings.map((h) => h.id).indexOf(heading.id);
       if (indexIn === -1) {
         uniqueHeadings.push(heading);
       }
@@ -572,6 +576,24 @@ export default class StructuralMetadataUtils {
     return uniqueHeadings;
   }
 
+  /**
+   * Get items after a given item in the structure
+   * @param {Object} currentItem
+   * @param {Array} allItems all items in the structure
+   * @param {Array} nextDivs heading items after the current item
+   */
+  getItemsAfter(currentItem, allItems, nextDivs) {
+    const parentItem = this.getParentDiv(currentItem, allItems);
+    const currentIndex = parentItem.items
+      .map((item) => item.id)
+      .indexOf(currentItem.id);
+    const nextItem = parentItem.items.filter((item, i) => i > currentIndex);
+    nextDivs = nextDivs.concat(nextItem);
+    if (this.getParentDiv(parentItem, allItems)) {
+      return this.getItemsAfter(parentItem, allItems, nextDivs);
+    }
+    return nextDivs;
+  }
   /**
    * Helper function which handles React Dnd's dropping of a dragSource onto a dropTarget
    * It needs to re-arrange the data structure to reflect the new positions
@@ -587,14 +609,14 @@ export default class StructuralMetadataUtils {
     // Slice out previous position of itemToMove
     let itemToMoveParent = this.getParentDiv(itemToMove, clonedItems);
     let itemToMoveItemIndex = itemToMoveParent.items
-      .map(item => item.id)
+      .map((item) => item.id)
       .indexOf(itemToMove.id);
     itemToMoveParent.items.splice(itemToMoveItemIndex, 1);
 
     // Place itemToMove right after the placeholder array position
     let dropTargetParent = this.getParentDiv(dropTarget, clonedItems);
     let dropTargetItemIndex = dropTargetParent.items
-      .map(item => item.id)
+      .map((item) => item.id)
       .indexOf(dropTarget.id);
     dropTargetParent.items.splice(dropTargetItemIndex, 0, itemToMove);
 
@@ -619,7 +641,7 @@ export default class StructuralMetadataUtils {
         id: uuidv1(),
         type: 'div',
         label: obj.headingTitle,
-        items: []
+        items: [],
       });
     }
 
@@ -643,11 +665,11 @@ export default class StructuralMetadataUtils {
     // Index the new timespan to be inserted
     let insertIndex = 0;
 
-    let getParentOfSpan = item => {
+    let getParentOfSpan = (item) => {
       let inFoundDiv = false;
       let closestSibling = null;
       const siblings = foundDiv.items;
-      siblings.map(sibling => {
+      siblings.map((sibling) => {
         if (sibling.id === item.id) {
           inFoundDiv = true;
           closestSibling = sibling;
@@ -669,13 +691,13 @@ export default class StructuralMetadataUtils {
         let siblingBefore = getParentOfSpan(before);
         if (siblingBefore) {
           insertIndex =
-            foundDiv.items.map(item => item.id).indexOf(siblingBefore.id) + 1;
+            foundDiv.items.map((item) => item.id).indexOf(siblingBefore.id) + 1;
         }
       } else if (after) {
         let siblingAfter = getParentOfSpan(after);
         if (siblingAfter) {
           let siblingAfterIndex = foundDiv.items
-            .map(item => item.id)
+            .map((item) => item.id)
             .indexOf(siblingAfter.id);
           insertIndex = siblingAfterIndex === 0 ? 0 : siblingAfterIndex - 1;
         }
@@ -696,14 +718,14 @@ export default class StructuralMetadataUtils {
    * @returns {Array}
    */
   removeActiveDragSources(allItems) {
-    let removeActive = parent => {
+    let removeActive = (parent) => {
       if (!parent.items) {
         if (parent.active) {
           parent.active = false;
         }
         return parent;
       }
-      parent.items = parent.items.map(child => removeActive(child));
+      parent.items = parent.items.map((child) => removeActive(child));
 
       return parent;
     };
@@ -724,8 +746,8 @@ export default class StructuralMetadataUtils {
       }
 
       parent.items = parent.items
-        .filter(child => child.type !== childTypeToRemove)
-        .map(child => removeFromTree(child, childTypeToRemove));
+        .filter((child) => child.type !== childTypeToRemove)
+        .map((child) => removeFromTree(child, childTypeToRemove));
 
       return parent;
     };
@@ -763,7 +785,7 @@ export default class StructuralMetadataUtils {
     let structureWithIds = cloneDeep(structureJS);
 
     // Recursively loop through data structure
-    let fn = items => {
+    let fn = (items) => {
       for (let item of items) {
         // Create and add an id
         item.id = uuidv1();
@@ -840,7 +862,7 @@ export default class StructuralMetadataUtils {
    */
   filterObjectKey(allitems, key) {
     let clonedItems = cloneDeep(allitems);
-    let removeKey = items => {
+    let removeKey = (items) => {
       for (let item of items) {
         if (key in item) {
           delete item.active;

--- a/src/services/__test__/StructuralMetadataUtils.test.js
+++ b/src/services/__test__/StructuralMetadataUtils.test.js
@@ -3,7 +3,7 @@ import {
   testSmData,
   testDataFromServer,
   testEmptyHeaderBefore,
-  testEmptyHeaderAfter
+  testEmptyHeaderAfter,
 } from '../testing-helpers';
 import { cloneDeep } from 'lodash';
 
@@ -26,7 +26,7 @@ describe('StructuralMetadataUtils class', () => {
       beginTime: '00:00:011',
       endTime: '00:00:021',
       timespanChildOf: '3bf42620-2321-11e9-aa56-f9563015e266',
-      timespanTitle: 'Tester'
+      timespanTitle: 'Tester',
     };
     const value = smu.createSpanObject(obj);
 
@@ -43,7 +43,7 @@ describe('StructuralMetadataUtils class', () => {
         type: 'div',
         label: 'Sub-Segment 1.1',
         id: '123a-456b-789c-2d',
-        items: []
+        items: [],
       };
       const value = smu.deleteListItem(obj.id, testData);
       expect(value).not.toContain(obj);
@@ -52,7 +52,7 @@ describe('StructuralMetadataUtils class', () => {
         label: 'Segment 1.1',
         id: '123a-456b-789c-3d',
         begin: '00:00:03.321',
-        end: '00:00:10.321'
+        end: '00:00:10.321',
       });
     });
     test('deletes a header with children', () => {
@@ -65,23 +65,23 @@ describe('StructuralMetadataUtils class', () => {
             type: 'div',
             label: 'Sub-Segment 1.1',
             id: '123a-456b-789c-2d',
-            items: []
+            items: [],
           },
           {
             type: 'span',
             label: 'Segment 1.1',
             id: '123a-456b-789c-3d',
             begin: '00:00:03.321',
-            end: '00:00:10.321'
+            end: '00:00:10.321',
           },
           {
             type: 'span',
             label: 'Segment 1.2',
             id: '123a-456b-789c-4d',
             begin: '00:00:11.231',
-            end: '00:08:00.001'
-          }
-        ]
+            end: '00:08:00.001',
+          },
+        ],
       };
       const value = smu.deleteListItem(obj.id, testData);
       expect(value).not.toContain(obj);
@@ -89,7 +89,7 @@ describe('StructuralMetadataUtils class', () => {
         type: 'div',
         label: 'Sub-Segment 2.1.1',
         id: '123a-456b-789c-7d',
-        items: []
+        items: [],
       });
     });
     test('deletes a childless header', () => {
@@ -97,7 +97,7 @@ describe('StructuralMetadataUtils class', () => {
         type: 'div',
         label: 'Sub-Segment 2.1.1',
         id: '123a-456b-789c-7d',
-        items: []
+        items: [],
       };
       const value = smu.deleteListItem(obj.id, testData);
       expect(value).not.toContain(obj);
@@ -106,7 +106,7 @@ describe('StructuralMetadataUtils class', () => {
         label: 'Segment 2.1',
         id: '123a-456b-789c-8d',
         begin: '00:09:03.241',
-        end: '00:15:00.001'
+        end: '00:15:00.001',
       });
     });
   });
@@ -205,7 +205,7 @@ describe('StructuralMetadataUtils class', () => {
       type: 'div',
       label: 'Sub-Segment 1.1',
       id: '123a-456b-789c-2d',
-      items: []
+      items: [],
     };
     const value = smu.findItem('123a-456b-789c-2d', testData);
     expect(value).toEqual(obj);
@@ -219,7 +219,7 @@ describe('StructuralMetadataUtils class', () => {
     test('before first timespan', () => {
       const obj = {
         begin: '00:00:00.000',
-        end: '00:00:03.321'
+        end: '00:00:03.321',
       };
       const expected = {
         before: null,
@@ -228,8 +228,8 @@ describe('StructuralMetadataUtils class', () => {
           label: 'Segment 1.1',
           begin: '00:00:03.321',
           end: '00:00:10.321',
-          id: '123a-456b-789c-3d'
-        }
+          id: '123a-456b-789c-3d',
+        },
       };
       const value = smu.findWrapperSpans(obj, allSpans);
       expect(value).toEqual(expected);
@@ -237,7 +237,7 @@ describe('StructuralMetadataUtils class', () => {
     test('in between existing timespans', () => {
       const obj = {
         begin: '00:00:10.321',
-        end: '00:00:11.231'
+        end: '00:00:11.231',
       };
       const expected = {
         before: {
@@ -245,15 +245,15 @@ describe('StructuralMetadataUtils class', () => {
           label: 'Segment 1.1',
           begin: '00:00:03.321',
           end: '00:00:10.321',
-          id: '123a-456b-789c-3d'
+          id: '123a-456b-789c-3d',
         },
         after: {
           type: 'span',
           label: 'Segment 1.2',
           id: '123a-456b-789c-4d',
           begin: '00:00:11.231',
-          end: '00:08:00.001'
-        }
+          end: '00:08:00.001',
+        },
       };
       const value = smu.findWrapperSpans(obj, allSpans);
       expect(value).toEqual(expected);
@@ -261,7 +261,7 @@ describe('StructuralMetadataUtils class', () => {
     test('after last timespan', () => {
       const obj = {
         begin: '00:15:00.001',
-        end: '00:20:00.001'
+        end: '00:20:00.001',
       };
       const expected = {
         before: {
@@ -269,9 +269,9 @@ describe('StructuralMetadataUtils class', () => {
           label: 'Segment 2.1',
           begin: '00:09:03.241',
           end: '00:15:00.001',
-          id: '123a-456b-789c-8d'
+          id: '123a-456b-789c-8d',
         },
-        after: null
+        after: null,
       };
       const value = smu.findWrapperSpans(obj, allSpans);
       expect(value).toEqual(expected);
@@ -290,9 +290,9 @@ describe('StructuralMetadataUtils class', () => {
             label: 'Act 1',
             id: '123a-456b-789c-3d',
             begin: '00:10:00.001',
-            end: '00:15:00.001'
-          }
-        ]
+            end: '00:15:00.001',
+          },
+        ],
       };
       const value = smu.findWrapperHeaders(obj, testEmptyHeaderBefore);
       const expected = {
@@ -300,9 +300,9 @@ describe('StructuralMetadataUtils class', () => {
           type: 'div',
           label: 'Scene 1',
           id: '123a-456b-789c-1d',
-          items: []
+          items: [],
         },
-        after: null
+        after: null,
       };
       expect(value).toEqual(expected);
     });
@@ -317,9 +317,9 @@ describe('StructuralMetadataUtils class', () => {
             label: 'Act 1',
             id: '123a-456b-789c-2d',
             begin: '00:00:00.000',
-            end: '00:09:00.001'
-          }
-        ]
+            end: '00:09:00.001',
+          },
+        ],
       };
       const value = smu.findWrapperHeaders(obj, testEmptyHeaderAfter);
       const expected = {
@@ -328,8 +328,8 @@ describe('StructuralMetadataUtils class', () => {
           type: 'div',
           label: 'Scene 2',
           id: '123a-456b-789c-3d',
-          items: []
-        }
+          items: [],
+        },
       };
       expect(value).toEqual(expected);
     });
@@ -341,40 +341,40 @@ describe('StructuralMetadataUtils class', () => {
         {
           type: 'div',
           label: 'Title',
-          id: '123a-456b-789c-0d'
+          id: '123a-456b-789c-0d',
         },
         {
           type: 'div',
           label: 'First segment',
-          id: '123a-456b-789c-1d'
+          id: '123a-456b-789c-1d',
         },
         {
           type: 'div',
           label: 'Sub-Segment 1.1',
-          id: '123a-456b-789c-2d'
+          id: '123a-456b-789c-2d',
         },
         {
           type: 'div',
           label: 'Second segment',
-          id: '123a-456b-789c-5d'
+          id: '123a-456b-789c-5d',
         },
         {
           type: 'div',
           label: 'Sub-Segment 2.1',
-          id: '123a-456b-789c-6d'
+          id: '123a-456b-789c-6d',
         },
         {
           type: 'div',
           label: 'Sub-Segment 2.1.1',
-          id: '123a-456b-789c-7d'
-        }
+          id: '123a-456b-789c-7d',
+        },
       ];
       const value = smu.getItemsOfType('div', testData);
       expect(value).toHaveLength(allDivs.length);
       expect(value).toContainEqual({
         type: 'div',
         label: 'Sub-Segment 2.1',
-        id: '123a-456b-789c-6d'
+        id: '123a-456b-789c-6d',
       });
     });
     test('type === span', () => {
@@ -384,22 +384,22 @@ describe('StructuralMetadataUtils class', () => {
           label: 'Segment 1.1',
           id: '123a-456b-789c-3d',
           begin: '00:00:03.321',
-          end: '00:00:10.321'
+          end: '00:00:10.321',
         },
         {
           type: 'span',
           label: 'Segment 1.2',
           id: '123a-456b-789c-4d',
           begin: '00:00:11.231',
-          end: '00:08:00.001'
+          end: '00:08:00.001',
         },
         {
           type: 'span',
           label: 'Segment 2.1',
           id: '123a-456b-789c-8d',
           begin: '00:09:03.241',
-          end: '00:15:00.001'
-        }
+          end: '00:15:00.001',
+        },
       ];
       const value = smu.getItemsOfType('span', testData);
       expect(value).toHaveLength(allSpans.length);
@@ -408,7 +408,7 @@ describe('StructuralMetadataUtils class', () => {
         label: 'Segment 2.1',
         id: '123a-456b-789c-8d',
         begin: '00:09:03.241',
-        end: '00:15:00.001'
+        end: '00:15:00.001',
       });
     });
   });
@@ -420,7 +420,7 @@ describe('StructuralMetadataUtils class', () => {
         label: 'Segment 1.2',
         id: '123a-456b-789c-4d',
         begin: '00:00:11.231',
-        end: '00:08:00.001'
+        end: '00:08:00.001',
       };
       const expected = {
         type: 'div',
@@ -431,23 +431,23 @@ describe('StructuralMetadataUtils class', () => {
             type: 'div',
             label: 'Sub-Segment 1.1',
             id: '123a-456b-789c-2d',
-            items: []
+            items: [],
           },
           {
             type: 'span',
             label: 'Segment 1.1',
             id: '123a-456b-789c-3d',
             begin: '00:00:03.321',
-            end: '00:00:10.321'
+            end: '00:00:10.321',
           },
           {
             type: 'span',
             label: 'Segment 1.2',
             id: '123a-456b-789c-4d',
             begin: '00:00:11.231',
-            end: '00:08:00.001'
-          }
-        ]
+            end: '00:08:00.001',
+          },
+        ],
       };
       const value = smu.getParentDiv(obj, testData);
       expect(value).toEqual(expected);
@@ -457,7 +457,7 @@ describe('StructuralMetadataUtils class', () => {
         type: 'div',
         label: 'Sub-Segment 2.1.1',
         id: '123a-456b-789c-7d',
-        items: []
+        items: [],
       };
       const expected = {
         type: 'div',
@@ -468,16 +468,16 @@ describe('StructuralMetadataUtils class', () => {
             type: 'div',
             label: 'Sub-Segment 2.1.1',
             id: '123a-456b-789c-7d',
-            items: []
+            items: [],
           },
           {
             type: 'span',
             label: 'Segment 2.1',
             id: '123a-456b-789c-8d',
             begin: '00:09:03.241',
-            end: '00:15:00.001'
-          }
-        ]
+            end: '00:15:00.001',
+          },
+        ],
       };
       const value = smu.getParentDiv(obj, testData);
       expect(value).toEqual(expected);
@@ -489,7 +489,7 @@ describe('StructuralMetadataUtils class', () => {
       const newSpan = { begin: '00:00:00.011', end: '00:02:00.001' };
       const wrapperSpans = {
         before: null,
-        after: null
+        after: null,
       };
       const structure = [
         {
@@ -501,40 +501,40 @@ describe('StructuralMetadataUtils class', () => {
               type: 'div',
               label: 'Scene 1',
               id: '123a-456b-789c-1d',
-              items: []
+              items: [],
             },
             {
               type: 'div',
               label: 'Scene 2',
               id: '123a-456b-789c-2d',
-              items: []
-            }
-          ]
-        }
+              items: [],
+            },
+          ],
+        },
       ];
       const expected = [
         {
           type: 'div',
           label: 'Title',
-          id: '123a-456b-789c-0d'
+          id: '123a-456b-789c-0d',
         },
         {
           type: 'div',
           label: 'Scene 1',
-          id: '123a-456b-789c-1d'
+          id: '123a-456b-789c-1d',
         },
         {
           type: 'div',
           label: 'Scene 2',
-          id: '123a-456b-789c-2d'
-        }
+          id: '123a-456b-789c-2d',
+        },
       ];
       const value = smu.getValidHeadings(newSpan, wrapperSpans, structure);
       expect(value).toHaveLength(expected.length);
       expect(value).toContainEqual({
         type: 'div',
         label: 'Scene 1',
-        id: '123a-456b-789c-1d'
+        id: '123a-456b-789c-1d',
       });
     });
     test('wrapped by existing timespans', () => {
@@ -545,44 +545,44 @@ describe('StructuralMetadataUtils class', () => {
           label: 'Segment 1.2',
           id: '123a-456b-789c-4d',
           begin: '00:00:11.231',
-          end: '00:08:00.001'
+          end: '00:08:00.001',
         },
         after: {
           type: 'span',
           label: 'Segment 2.1',
           id: '123a-456b-789c-8d',
           begin: '00:09:03.241',
-          end: '00:15:00.001'
-        }
+          end: '00:15:00.001',
+        },
       };
       const expected = [
         {
           type: 'div',
           label: 'First segment',
-          id: '123a-456b-789c-1d'
+          id: '123a-456b-789c-1d',
         },
         {
           type: 'div',
           label: 'Second segment',
-          id: '123a-456b-789c-5d'
+          id: '123a-456b-789c-5d',
         },
         {
           type: 'div',
           label: 'Sub-Segment 2.1',
-          id: '123a-456b-789c-6d'
+          id: '123a-456b-789c-6d',
         },
         {
           type: 'div',
           label: 'Sub-Segment 2.1.1',
-          id: '123a-456b-789c-7d'
-        }
+          id: '123a-456b-789c-7d',
+        },
       ];
       const value = smu.getValidHeadings(newSpan, wrapperSpans, testData);
       expect(value).toHaveLength(expected.length);
       expect(value).toContainEqual({
         type: 'div',
         label: 'Sub-Segment 2.1',
-        id: '123a-456b-789c-6d'
+        id: '123a-456b-789c-6d',
       });
     });
     test('no wrapping timespans after', () => {
@@ -593,33 +593,38 @@ describe('StructuralMetadataUtils class', () => {
           label: 'Segment 2.1',
           id: '123a-456b-789c-8d',
           begin: '00:09:03.241',
-          end: '00:15:00.001'
+          end: '00:15:00.001',
         },
-        after: null
+        after: null,
       };
       const expected = [
         {
           type: 'div',
           label: 'Title',
-          id: '123a-456b-789c-0d'
+          id: '123a-456b-789c-0d',
         },
         {
           type: 'div',
           label: 'Second segment',
-          id: '123a-456b-789c-5d'
+          id: '123a-456b-789c-5d',
         },
         {
           type: 'div',
           label: 'Sub-Segment 2.1',
-          id: '123a-456b-789c-6d'
-        }
+          id: '123a-456b-789c-6d',
+        },
+        {
+          type: 'div',
+          label: 'A ',
+          id: '123a-456b-789c-9d',
+        },
       ];
       const value = smu.getValidHeadings(newSpan, wrapperSpans, testData);
       expect(value).toHaveLength(expected.length);
       expect(value).toContainEqual({
         type: 'div',
         label: 'Sub-Segment 2.1',
-        id: '123a-456b-789c-6d'
+        id: '123a-456b-789c-6d',
       });
     });
     test('no wrapping span before', () => {
@@ -631,33 +636,124 @@ describe('StructuralMetadataUtils class', () => {
           label: 'Act 1',
           id: '123a-456b-789c-3d',
           begin: '00:00:03.321',
-          end: '00:00:10.321'
-        }
+          end: '00:00:10.321',
+        },
       };
       const expected = [
         {
           type: 'div',
           label: 'Title',
-          id: '123a-456b-789c-0d'
+          id: '123a-456b-789c-0d',
         },
         {
           type: 'div',
           label: 'First segment',
-          id: '123a-456b-789c-1d'
+          id: '123a-456b-789c-1d',
         },
         {
           type: 'div',
           label: 'Sub-Segment 1.1',
-          id: '123a-456b-789c-2d'
-        }
+          id: '123a-456b-789c-2d',
+        },
       ];
       const value = smu.getValidHeadings(newSpan, wrapperSpans, testData);
       expect(value).toHaveLength(expected.length);
       expect(value).toContainEqual({
         type: 'div',
         label: 'Sub-Segment 1.1',
-        id: '123a-456b-789c-2d'
+        id: '123a-456b-789c-2d',
       });
+    });
+  });
+
+  describe('get element after', () => {
+    test('a timespan in the middle of the structure', () => {
+      const expected = [
+        {
+          type: 'span',
+          label: 'Segment 1.2',
+          id: '123a-456b-789c-4d',
+          begin: '00:00:11.231',
+          end: '00:08:00.001',
+        },
+        {
+          type: 'div',
+          label: 'Second segment',
+          id: '123a-456b-789c-5d',
+          items: [
+            {
+              type: 'div',
+              label: 'Sub-Segment 2.1',
+              id: '123a-456b-789c-6d',
+              items: [
+                {
+                  type: 'div',
+                  label: 'Sub-Segment 2.1.1',
+                  id: '123a-456b-789c-7d',
+                  items: [],
+                },
+                {
+                  type: 'span',
+                  label: 'Segment 2.1',
+                  id: '123a-456b-789c-8d',
+                  begin: '00:09:03.241',
+                  end: '00:15:00.001',
+                },
+              ],
+            },
+          ],
+        },
+        {
+          type: 'div',
+          label: 'A ',
+          id: '123a-456b-789c-9d',
+          items: [],
+        },
+      ];
+      const currentItem = {
+        type: 'span',
+        label: 'Segment 1.1',
+        id: '123a-456b-789c-3d',
+        begin: '00:00:03.321',
+        end: '00:00:10.321',
+      };
+      const value = smu.getItemsAfter(currentItem, testData, []);
+      expect(value).toHaveLength(expected.length);
+      expect(value).toEqual(expected);
+    });
+
+    test('last leaf node in the structure', () => {
+      const currentItem = {
+        type: 'span',
+        label: 'Segment 2.1',
+        id: '123a-456b-789c-8d',
+        begin: '00:09:03.241',
+        end: '00:15:00.001',
+      };
+
+      const expected = [
+        {
+          type: 'div',
+          label: 'A ',
+          id: '123a-456b-789c-9d',
+          items: [],
+        },
+      ];
+      const value = smu.getItemsAfter(currentItem, testData, []);
+      expect(value).toHaveLength(expected.length);
+      expect(value).toEqual(expected);
+    });
+
+    test('last node in the structure', () => {
+      const currentItem = {
+        type: 'div',
+        label: 'A',
+        id: '123a-456b-789c-9d',
+        items: [],
+      };
+
+      const value = smu.getItemsAfter(currentItem, testData, []);
+      expect(value).toHaveLength(0);
     });
   });
 

--- a/src/services/testing-helpers.js
+++ b/src/services/testing-helpers.js
@@ -20,13 +20,13 @@ export function renderWithRedux(
   ui,
   {
     initialState,
-    store = createStore(reducer, initialState, applyMiddleware(thunk))
+    store = createStore(reducer, initialState, applyMiddleware(thunk)),
   } = {},
   renderFn = render
 ) {
   const obj = {
     ...renderFn(<Provider store={store}>{ui}</Provider>),
-    store
+    store,
   };
   obj.rerenderWithRedux = (el, nextState) => {
     if (nextState) {
@@ -54,23 +54,23 @@ export const testSmData = [
             type: 'div',
             label: 'Sub-Segment 1.1',
             id: '123a-456b-789c-2d',
-            items: []
+            items: [],
           },
           {
             type: 'span',
             label: 'Segment 1.1',
             id: '123a-456b-789c-3d',
             begin: '00:00:03.321',
-            end: '00:00:10.321'
+            end: '00:00:10.321',
           },
           {
             type: 'span',
             label: 'Segment 1.2',
             id: '123a-456b-789c-4d',
             begin: '00:00:11.231',
-            end: '00:08:00.001'
-          }
-        ]
+            end: '00:08:00.001',
+          },
+        ],
       },
       {
         type: 'div',
@@ -86,27 +86,27 @@ export const testSmData = [
                 type: 'div',
                 label: 'Sub-Segment 2.1.1',
                 id: '123a-456b-789c-7d',
-                items: []
+                items: [],
               },
               {
                 type: 'span',
                 label: 'Segment 2.1',
                 id: '123a-456b-789c-8d',
                 begin: '00:09:03.241',
-                end: '00:15:00.001'
-              }
-            ]
-          }
-        ]
+                end: '00:15:00.001',
+              },
+            ],
+          },
+        ],
       },
       {
         type: 'div',
         label: 'A ',
         id: '123a-456b-789c-9d',
-        items: []
-      }
-    ]
-  }
+        items: [],
+      },
+    ],
+  },
 ];
 
 export const testDataFromServer = [
@@ -120,38 +120,38 @@ export const testDataFromServer = [
         label: 'First segment',
         id: '123a-456b-789c-1d',
         begin: '41.45',
-        end: '42'
+        end: '42',
       },
       {
         type: 'span',
         label: 'Middle segment',
         id: '123a-456b-789c-2d',
         begin: '00:10:42',
-        end: '00:15:00.23'
+        end: '00:15:00.23',
       },
       {
         type: 'span',
         label: 'Segmet 1',
         id: '123a-456b-789c-3d',
         begin: '15:30',
-        end: '16:00.23'
+        end: '16:00.23',
       },
       {
         type: 'span',
         label: 'Segment 2',
         id: '123a-456b-789c-4d',
         begin: '16:30',
-        end: '00:38:58'
+        end: '00:38:58',
       },
       {
         type: 'span',
         label: 'Final segment',
         id: '123a-456b-789c-5d',
         begin: '17:00',
-        end: 'NaN:NaN:NaN'
-      }
-    ]
-  }
+        end: 'NaN:NaN:NaN',
+      },
+    ],
+  },
 ];
 
 export const testEmptyHeaderBefore = [
@@ -164,7 +164,7 @@ export const testEmptyHeaderBefore = [
         type: 'div',
         label: 'Scene 1',
         id: '123a-456b-789c-1d',
-        items: []
+        items: [],
       },
       {
         type: 'div',
@@ -176,12 +176,12 @@ export const testEmptyHeaderBefore = [
             label: 'Act 1',
             id: '123a-456b-789c-3d',
             begin: '00:10:00.001',
-            end: '00:15:00.001'
-          }
-        ]
-      }
-    ]
-  }
+            end: '00:15:00.001',
+          },
+        ],
+      },
+    ],
+  },
 ];
 
 export const testEmptyHeaderAfter = [
@@ -200,16 +200,16 @@ export const testEmptyHeaderAfter = [
             label: 'Act 1',
             id: '123a-456b-789c-2d',
             begin: '00:00:00.000',
-            end: '00:09:00.001'
-          }
-        ]
+            end: '00:09:00.001',
+          },
+        ],
       },
       {
         type: 'div',
         label: 'Scene 2',
         id: '123a-456b-789c-3d',
-        items: []
-      }
-    ]
-  }
+        items: [],
+      },
+    ],
+  },
 ];


### PR DESCRIPTION
When adding a new timespan the parents suggestion list in the timespan form doesn't include childless headings comes after the new timespan. And this PR fixes that bug.