### PR TITLE
Fix 403 error in fetching stream files

### DIFF
--- a/dist/actions/forms.js
+++ b/dist/actions/forms.js
@@ -197,6 +197,9 @@ function retrieveStreamMedia(audioFile, mediaPlayer) {
           }
 
           dispatch(streamMediaError(errorCode));
+        } else if (data.levelRetry) {
+          // Check if HLS.js is still trying to fetch stream
+          dispatch(setStreamMediaLoading(1));
         } else {
           dispatch(setStreamMediaLoading(0));
         }

--- a/dist/components/Waveform.js
+++ b/dist/components/Waveform.js
@@ -27,8 +27,6 @@ var _Slider = _interopRequireDefault(require("./Slider"));
 
 var _LoadingSpinner = _interopRequireDefault(require("../services/LoadingSpinner"));
 
-var _utils = require("../services/utils");
-
 // Content of aria-label for UI components
 var waveformLabel = "Two interactive waveforms, plotted one after the other using data from a masterfile in a back-end server.\nThere are time-based visual sections plotted in these 2 waveforms representing each timespan in the structure below.";
 var zoomViewLabel = "A detailed portion of the waveform data, the level of details shown can be changed with zoom in/out buttons in the waveform toolbar";
@@ -124,16 +122,12 @@ var Waveform = /*#__PURE__*/_react["default"].forwardRef(function (props, ref) {
   }, [editingDisabled]);
 
   _react["default"].useEffect(function () {
-    setPeaksIsReady(readyPeaks);
-    var mimeType = (0, _utils.getMimetype)(audioFile); // When given a .m3u8 playlist, use HLS to stream media
+    setPeaksIsReady(readyPeaks); // When given a .m3u8 playlist, use HLS to stream media
 
     if (readyPeaks && mediaInfo.isStream) {
       dispatch((0, _forms.retrieveStreamMedia)(audioFile, ref.mediaPlayerRef.current, {
         withCredentials: props.withCredentials
       }));
-    } else {
-      // Given a audio/video file, the HTML player handles the playback
-      dispatch((0, _forms.streamMediaSuccess)());
     }
   }, [readyPeaks]);
 
@@ -151,6 +145,10 @@ var Waveform = /*#__PURE__*/_react["default"].forwardRef(function (props, ref) {
       event.preventDefault();
       ref.mediaPlayerRef.current.paused ? playAudio() : pauseAudio();
     }
+  };
+
+  var handleCanplay = function handleCanplay() {
+    dispatch((0, _forms.streamMediaSuccess)());
   };
 
   var zoomIn = function zoomIn() {
@@ -200,7 +198,8 @@ var Waveform = /*#__PURE__*/_react["default"].forwardRef(function (props, ref) {
     hidden: true,
     controls: "controls",
     "data-testid": "waveform-media",
-    src: audioFile
+    src: audioFile,
+    onCanPlay: handleCanplay
   }, "Your browser does not support the audio element."), !streamMediaLoading && !streamMediaError && /*#__PURE__*/_react["default"].createElement(_reactBootstrap.Row, {
     "data-testid": "waveform-toolbar"
   }, /*#__PURE__*/_react["default"].createElement(_reactBootstrap.Col, {

--- a/src/actions/forms.js
+++ b/src/actions/forms.js
@@ -114,7 +114,7 @@ export function retrieveStreamMedia(audioFile, mediaPlayer, opts = {}) {
 
       // ERROR event is fired when fetching media stream is not successful
       hls.on(Hls.Events.ERROR, function (event, data) {
-        dispatch(setStreamMediaLoading(1))
+        dispatch(setStreamMediaLoading(1));
         let errorCode = null;
         // When there are errors in the HLS build this block catches it and flashes
         // the warning message for a split second. The ErrorType for these errors is
@@ -131,6 +131,9 @@ export function retrieveStreamMedia(audioFile, mediaPlayer, opts = {}) {
             errorCode = -6;
           }
           dispatch(streamMediaError(errorCode));
+        } else if(data.levelRetry) {
+          // Check if HLS.js is still trying to fetch stream
+          dispatch(setStreamMediaLoading(1));
         } else {
           dispatch(setStreamMediaLoading(0));
         }

--- a/src/components/Waveform.js
+++ b/src/components/Waveform.js
@@ -16,7 +16,6 @@ import {
 } from '../actions/forms';
 import VolumeSlider from './Slider';
 import LoadingSpinner from '../services/LoadingSpinner';
-import { getMimetype } from '../services/utils';
 
 // Content of aria-label for UI components
 const waveformLabel = `Two interactive waveforms, plotted one after the other using data from a masterfile in a back-end server.
@@ -89,7 +88,6 @@ const Waveform = React.forwardRef((props, ref) => {
   React.useEffect(() => {
     setPeaksIsReady(readyPeaks);
 
-    const mimeType = getMimetype(audioFile);
     // When given a .m3u8 playlist, use HLS to stream media
     if (readyPeaks && mediaInfo.isStream) {
       dispatch(
@@ -97,9 +95,6 @@ const Waveform = React.forwardRef((props, ref) => {
           withCredentials: props.withCredentials,
         })
       );
-    } else {
-      // Given a audio/video file, the HTML player handles the playback
-      dispatch(streamMediaSuccess());
     }
   }, [readyPeaks]);
 
@@ -118,6 +113,10 @@ const Waveform = React.forwardRef((props, ref) => {
       ref.mediaPlayerRef.current.paused ? playAudio() : pauseAudio();
     }
   };
+
+  const handleCanplay = () => {
+    dispatch(streamMediaSuccess());
+  } 
 
   const zoomIn = () => {
     peaksInstance.zoom.zoomIn();
@@ -174,6 +173,7 @@ const Waveform = React.forwardRef((props, ref) => {
         controls="controls"
         data-testid="waveform-media"
         src={audioFile}
+        onCanPlay={handleCanplay}
       >
         Your browser does not support the audio element.
       </audio>


### PR DESCRIPTION
Wait for HLS.js to finish re-trying to fetch stream when a 403 error occurs, without removing the loading spinner blocking the UI.