### PR TITLE
Disable save structure button when editing structure

### DIFF
--- a/src/containers/StructureOutputContainer.js
+++ b/src/containers/StructureOutputContainer.js
@@ -15,7 +15,7 @@ const StructureOutputContainer = (props) => {
   const dispatch = useDispatch();
   const { manifestFetched } = useSelector((state) => state.manifest);
   const { smData, initSmData, smDataIsValid } = useSelector((state) => state.structuralMetadata);
-  const { editingDisabled, structureInfo } = useSelector((state) => state.forms);
+  const { structureInfo, editingDisabled } = useSelector((state) => state.forms);
 
   const [stateInitStructure, setInitStructure] = useState(initSmData);
 
@@ -69,27 +69,27 @@ const StructureOutputContainer = (props) => {
       data-testid="structure-output-section"
     >
       <Col lg={12} className="structure-lists">
-        { manifestFetched && smData != null && (
+        {manifestFetched && smData != null && (
           <div data-testid="structure-output-list">
             <List items={smData} />
           </div>)
         }
       </Col>
-      { !props.disableSave && (
+      {!props.disableSave && (
         <Row>
           <Col md={{ span: 4, offset: 8 }} className="text-right pr-4 pt-2">
             <Button
               variant="primary"
               onClick={handleSaveItClick}
               data-testid="structure-save-button"
-              disabled={props.editingDisabled}
+              disabled={editingDisabled}
             >
               Save Structure
             </Button>
           </Col>
         </Row>)
       }
-      
+
     </section>
   );
 };


### PR DESCRIPTION
In SME `Save Structure` button is supposed to be disabled when editing the structure. This was broken since the prop that was expected to be enabling/disabling the button was removed in the `SturcutreOutputContainer` component. This PR fixes this bug.