### PR TITLE
Move Bootstrap to peerDeps, cleanup Bootstrap 4 refs and classes

### DIFF
--- a/demo/src/app.js
+++ b/demo/src/app.js
@@ -5,6 +5,7 @@ import InputGroup from 'react-bootstrap/InputGroup';
 import Container from 'react-bootstrap/Container';
 import Card from 'react-bootstrap/Card';
 import Root from '../../src';
+import 'bootstrap/dist/css/bootstrap.min.css';
 import './app.css';
 
 const App = (props) => {

--- a/demo/src/index.html
+++ b/demo/src/index.html
@@ -1,23 +1,17 @@
 <html>
-  <head>
-    <title>Structural Metadata Editor - Demo</title>
-    <meta charset="utf-8" />
-    <meta
-      name="viewport"
-      content="width=device-width, initial-scale=1, shrink-to-fit=no"
-    />
-    <link 
-      rel="stylesheet" 
-      href="https://cdn.jsdelivr.net/npm/bootstrap@4.6.1/dist/css/bootstrap.min.css" 
-      integrity="sha384-zCbKRCUGaJDkqS1kPbPd7TveP5iyJE0EjAuZQTgFLD2ylzuqKfdKlfG/eSrtxUkn" 
-      crossorigin="anonymous" />
-    <link rel="icon" href="data:," />
-  </head>
 
-  <body>
-    <noscript>
-      You need to enable JavaScript to run this app.
-    </noscript>
-    <div id="root"></div>
-  </body>
+<head>
+  <title>Structural Metadata Editor - Demo</title>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
+  <link rel="icon" href="data:," />
+</head>
+
+<body>
+  <noscript>
+    You need to enable JavaScript to run this app.
+  </noscript>
+  <div id="root"></div>
+</body>
+
 </html>

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
   "license": "ISC",
   "peerDependencies": {
     "react": "^19.0.0",
-    "react-dom": "^19.0.0"
+    "react-dom": "^19.0.0",
+    "bootstrap": "^5.3.7"
   },
   "devDependencies": {
     "@babel/cli": "^7.27.0",
@@ -32,6 +33,7 @@
     "@testing-library/react": "^16.2.0",
     "@webpack-cli/serve": "^2.0.1",
     "babel-loader": "^10.0.0",
+    "bootstrap": "^5.3.7",
     "copy-webpack-plugin": "^13.0.0",
     "css-loader": "^7.1.2",
     "html-webpack-plugin": "^5.5.0",
@@ -52,7 +54,6 @@
     "@fortawesome/free-solid-svg-icons": "^6.7.2",
     "@fortawesome/react-fontawesome": "^0.2.2",
     "axios": "^1.8.4",
-    "bootstrap": "^5.3.3",
     "hls.js": "^1.6.0",
     "konva": "^9.3.20",
     "lodash": "4.17.21",

--- a/public/dev/manifest.json
+++ b/public/dev/manifest.json
@@ -326,7 +326,7 @@
                   "type": "Range",
                   "label": {
                     "en": [
-                      "Leavning the Lunchroom"
+                      "Leaving the Lunchroom"
                     ]
                   },
                   "items": [

--- a/public/prod/manifest.json
+++ b/public/prod/manifest.json
@@ -326,7 +326,7 @@
                   "type": "Range",
                   "label": {
                     "en": [
-                      "Leavning the Lunchroom"
+                      "Leaving the Lunchroom"
                     ]
                   },
                   "items": [

--- a/src/App.js
+++ b/src/App.js
@@ -1,6 +1,5 @@
 import React, { useEffect } from 'react';
 import PropTypes from 'prop-types';
-import 'bootstrap/dist/css/bootstrap.min.css';
 import './App.css';
 import WaveformContainer from './containers/WaveformContainer';
 import ButtonSection from './components/ButtonSection';

--- a/src/components/HeadingForm.js
+++ b/src/components/HeadingForm.js
@@ -99,11 +99,11 @@ const HeadingForm = ({ cancelClick, onSubmit }) => {
       </Form.Group>
 
       <Row>
-        <Col sm={{ offset: 5 }} md={{ offset: 5 }} lg={{ offset: 10 }}>
-          <ButtonToolbar className='float-right'>
+        <Col>
+          <ButtonToolbar className='float-end'>
             <Button
               variant='outline-secondary'
-              className='mr-1'
+              className='me-1'
               onClick={cancelClick}
               data-testid='heading-form-cancel-button'
             >

--- a/src/components/ListItemControls.js
+++ b/src/components/ListItemControls.js
@@ -86,7 +86,7 @@ const ListItemControls = ({ handleDelete, handleEditClick, handleShowDropTargets
           size='sm'
           onClick={handleConfirmDelete}
           data-testid='delete-confirmation-confirm-btn'
-          className='mr-1'
+          className='me-1'
         >
           Delete
         </Button>

--- a/src/components/TimespanForm.js
+++ b/src/components/TimespanForm.js
@@ -248,11 +248,11 @@ const TimespanForm = ({
       </Form.Group>
 
       <Row>
-        <Col sm={{ offset: 5 }} md={{ offset: 5 }} lg={{ offset: 10 }}>
-          <ButtonToolbar className='float-right'>
+        <Col>
+          <ButtonToolbar className='float-end'>
             <Button
               variant='outline-secondary'
-              className='mr-1'
+              className='me-1'
               onClick={handleCancelClick}
               data-testid='timespan-form-cancel-button'
             >

--- a/src/components/TimespanInlineForm.js
+++ b/src/components/TimespanInlineForm.js
@@ -198,7 +198,7 @@ function TimespanInlineForm({ cancelFn, item, isInitializing, isTyping, saveFn, 
   return (
     <div className='row-wrapper d-flex justify-content-between gap-5 px-0'>
       <Form data-testid='timespan-inline-form' className='mb-0 d-flex gap-4 flex-wrap flex-lg-nowrap no-gutters'>
-        <Form.Group as={Row} controlId='timespanTitle' className='ml-0'>
+        <Form.Group as={Row} controlId='timespanTitle' className='ms-0'>
           <Form.Label column sm={2} md={3}>Title</Form.Label>
           <Col sm={10} md={9} className='px-0'>
             <Form.Control
@@ -213,7 +213,7 @@ function TimespanInlineForm({ cancelFn, item, isInitializing, isTyping, saveFn, 
             />
           </Col>
         </Form.Group>
-        <Form.Group as={Row} controlId='beginTime' className='ml-0'>
+        <Form.Group as={Row} controlId='beginTime' className='ms-0'>
           <Form.Label column sm={2} md={3}>Begin</Form.Label>
           <Col sm={10} md={9} className='px-0'>
             <Form.Control
@@ -228,7 +228,7 @@ function TimespanInlineForm({ cancelFn, item, isInitializing, isTyping, saveFn, 
             />
           </Col>
         </Form.Group>
-        <Form.Group as={Row} controlId='endTime' className='ml-0'>
+        <Form.Group as={Row} controlId='endTime' className='ms-0'>
           <Form.Label column sm={2} md={3}>End</Form.Label>
           <Col sm={10} md={9} className='px-0'>
             <Form.Control

--- a/src/components/Waveform.js
+++ b/src/components/Waveform.js
@@ -183,7 +183,7 @@ const Waveform = forwardRef(({ }, ref) => {
                 onClick={playAudio}
                 data-testid="waveform-play-button"
                 disabled={streamMediaError || streamMediaLoading}
-                className="mr-1"
+                className="me-1"
               >
                 <FontAwesomeIcon icon={faPlay} />
               </Button>
@@ -193,7 +193,7 @@ const Waveform = forwardRef(({ }, ref) => {
                 onClick={pauseAudio}
                 data-testid="waveform-pause-button"
                 disabled={streamMediaError || streamMediaLoading}
-                className="mr-1"
+                className="me-1"
               >
                 <FontAwesomeIcon icon={faPause} />
               </Button>
@@ -202,7 +202,7 @@ const Waveform = forwardRef(({ }, ref) => {
                 aria-label="Zoom in"
                 onClick={zoomIn}
                 data-testid="waveform-zoomin-button"
-                className="mr-1"
+                className="me-1"
               >
                 <FontAwesomeIcon icon={faSearchPlus} />
               </Button>

--- a/src/containers/StructureOutputContainer.js
+++ b/src/containers/StructureOutputContainer.js
@@ -85,12 +85,13 @@ const StructureOutputContainer = ({ disableSave, structureIsSaved, structureURL 
       </Col>
       {!disableSave && (
         <Row>
-          <Col md={{ span: 4, offset: 8 }} className="text-right pr-4 pt-2">
+          <Col className="pt-2">
             <Button
               variant="primary"
               onClick={handleSaveItClick}
               data-testid="structure-save-button"
               disabled={editingDisabled}
+              className="float-end"
             >
               Save Structure
             </Button>

--- a/src/containers/WaveformContainer.js
+++ b/src/containers/WaveformContainer.js
@@ -99,13 +99,9 @@ const useWaveform = ({ canvasIndex, manifestURL, withCredentials }) => {
       mediaElement: mediaPlayer.current,
       player: null,
     };
-    // try {
     if (!streamMediaLoading && smData != [] && !readyPeaks) {
       initPeaks(peaksOptions, smData);
     }
-    // } catch (error) {
-    //   showBoundary(error);
-    // }
   }, [streamMediaLoading]);
   return { zoomView, overView, mediaPlayer };
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -2176,10 +2176,10 @@ boolbase@^1.0.0:
   resolved "https://registry.yarnpkg.com/boolbase/-/boolbase-1.0.0.tgz#68dff5fbe60c51eb37725ea9e3ed310dcc1e776e"
   integrity sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==
 
-bootstrap@^5.3.3:
-  version "5.3.3"
-  resolved "https://registry.yarnpkg.com/bootstrap/-/bootstrap-5.3.3.tgz#de35e1a765c897ac940021900fcbb831602bac38"
-  integrity sha512-8HLCdWgyoMguSO9o+aH+iuZ+aht+mzW0u3HIMzVu7Srrpv7EBBxTnrFlSCskwdY1+EOFQSm7uMJhNQHkdPcmjg==
+bootstrap@^5.3.7:
+  version "5.3.7"
+  resolved "https://registry.yarnpkg.com/bootstrap/-/bootstrap-5.3.7.tgz#8640065036124d961d885d80b5945745e1154d90"
+  integrity sha512-7KgiD8UHjfcPBHEpDNg+zGz8L3LqR3GVwqZiBRFX04a1BCArZOz1r2kjly2HQ0WokqTO0v1nF+QAt8dsW4lKlw==
 
 brace-expansion@^1.1.7:
   version "1.1.11"
@@ -5425,7 +5425,16 @@ string-length@^4.0.1:
     char-regex "^1.0.2"
     strip-ansi "^6.0.0"
 
-"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0":
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
+
+string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -5457,7 +5466,14 @@ string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
+
+strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -5982,7 +5998,16 @@ wildcard@^2.0.1:
   resolved "https://registry.yarnpkg.com/wildcard/-/wildcard-2.0.1.tgz#5ab10d02487198954836b6349f74fff961e10f67"
   integrity sha512-CC1bOL87PIWSBhDcTrdeLo6eGT7mCFtrg0uIJtqJUFyK+eJnzl8A1niH56uu7KMa5XFrtiV+AQuHO3n7DsHnLQ==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
+  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+
+wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==


### PR DESCRIPTION
The latest `react-bootstrap` version no longer bundles all Bootstrap 5 classes, so SME now requires `bootstrap` to be installed as a separate dependency. Previously, `react-bootstrap` included these classes, removing the need for a standalone `bootstrap` installation.

Currently, SME is installing the `bootstrap` JavaScript library as a direct dependency and importing its CSS at the root level of our exported component. This approach creates several issues for consuming applications:
- Redundant Dependencies: When a consuming application (like Avalon) installs our component, it also installs `bootstrap`. This is redundant if the consuming application already uses its own Bootstrap installation (e.g., `bootstrap` gem).
- Styling Conflicts and Overrides: Importing Bootstrap's CSS directly within the exportable component's code prevents consuming applications from effectively overriding Bootstrap styles within the component. This can lead to significant styling conflicts and even breaking changes in the consuming application's UI.

To fix these issues, this PR is making the following changes:
- install `bootstrap` as a `peerDependency`: By listing `bootstrap` as a `peerDependency`, consuming applications will have the flexibility to install and manage their own bootstrap version. This prevents redundant installations and potential conflicts.
- move the Bootstrap CSS import outside of the exportable component. This gives consuming applications more control over Bootstrap styles, reducing the risk of conflicts. (For demo purposes, the CSS import will be managed externally.)

This PR also includes a cleanup of Bootstrap 4 classes and imports that were missed (in `index.html`) in previous refactoring work.