### PR TITLE
Add support for creating headings inside timespans with children

### DIFF
--- a/src/components/HeadingForm.js
+++ b/src/components/HeadingForm.js
@@ -44,17 +44,15 @@ const HeadingForm = ({ cancelClick, onSubmit }) => {
   };
 
   const getOptions = () => {
-    const rootHeader = structuralMetadataUtils.getItemsOfType('root', smData);
-    const divHeaders = structuralMetadataUtils.getItemsOfType('div', smData);
     /**
-     * Only get timespans with children as possible headings.
+     * Only get type='span' (timespans) items with children as possible headings.
      * This helps to keep the options list smaller, but allows to add heading
      * inside timespans. These headings then can be used as drop-zones for child
      * timespans inside them.
      */
-    const spanHeaders = structuralMetadataUtils.getItemsOfType('span', smData)
-      .filter(s => s.items?.length > 0);
-    const allHeaders = [...rootHeader, ...divHeaders, ...spanHeaders];
+    const allHeaders = structuralMetadataUtils
+      .getItemsOfType(['root', 'div', 'span'], smData)
+      .filter(h => h.type !== 'span' || (h.items && h.items.length > 0));
     const options = allHeaders.map((header) => (
       <option value={header.id} key={header.id}>
         {header.label}

--- a/src/components/TimespanForm.js
+++ b/src/components/TimespanForm.js
@@ -45,7 +45,7 @@ const TimespanForm = ({
 
   const allSpans = useMemo(() => {
     if (smData?.length > 0) {
-      return structuralMetadataUtils.getItemsOfType('span', smData);
+      return structuralMetadataUtils.getItemsOfType(['span'], smData);
     }
   }, [smData]);
 

--- a/src/components/TimespanInlineForm.js
+++ b/src/components/TimespanInlineForm.js
@@ -89,10 +89,7 @@ function TimespanInlineForm({ cancelFn, item, isInitializing, isTyping, saveFn, 
     );
 
     // Save a reference to all the spans for future calculations
-    allSpansRef.current = structuralMetadataUtils.getItemsOfType(
-      'span',
-      tempSmDataRef.current
-    );
+    allSpansRef.current = structuralMetadataUtils.getItemsOfType(['span'], tempSmDataRef.current);
 
     // Get segment from current peaks instance
     const currentSegment = peaksInstance.peaks.segments.getSegment(item.id);
@@ -136,13 +133,10 @@ function TimespanInlineForm({ cancelFn, item, isInitializing, isTyping, saveFn, 
    */
   const handleInvalidTimespan = () => {
     const itemIndex = structuralMetadataUtils
-      .getItemsOfType('span', smData)
+      .getItemsOfType(['span'], smData)
       .findIndex((i) => i.id === item.id);
 
-    const allSpans = structuralMetadataUtils.getItemsOfType(
-      'span',
-      tempSmDataRef.current
-    );
+    const allSpans = structuralMetadataUtils.getItemsOfType(['span'], tempSmDataRef.current);
 
     const wrapperSpans = { prevSpan: null, nextSpan: null };
     wrapperSpans.prevSpan = allSpans[itemIndex - 1] || null;

--- a/src/components/__tests__/HeadingForm.test.js
+++ b/src/components/__tests__/HeadingForm.test.js
@@ -132,6 +132,6 @@ describe('HeadingForm component', () => {
     expect(el.children.length).toBe(7);
     expect(el.children[1].value).toBe('123a-456b-789c-0d');
     // Adds parent timespan to the options list
-    expect(el.children[6].value).toBe('123a-456b-789c-6d');
+    expect(el.children[5].value).toBe('123a-456b-789c-6d');
   });
 });

--- a/src/services/StructuralMetadataUtils.js
+++ b/src/services/StructuralMetadataUtils.js
@@ -148,7 +148,7 @@ export default class StructuralMetadataUtils {
 
     // Set the scope of the drop-zones based on the dragSource
     let scopedItems = clonedItems;
-    let allSpans = this.getItemsOfType('span', clonedItems);
+    let allSpans = this.getItemsOfType(['span'], clonedItems);
     let parent = this.getParentItem(dragSource, clonedItems);
     let siblings = parent ? parent.items : [];
     let spanIndex = siblings.map((sibling) => sibling.id).indexOf(dragSource.id);
@@ -158,7 +158,7 @@ export default class StructuralMetadataUtils {
       scopedItems = [parent];
       // For nested timespans, scope drop target calculation within parent timespan only
       parent = this.getParentItem(dragSource, clonedItems);
-      allSpans = this.getItemsOfType('span', [parent]);
+      allSpans = this.getItemsOfType(['span'], [parent]);
       siblings = parent ? parent.items : [];
       const siblingHeadings = siblings.filter(sib => sib.type === 'div');
 
@@ -181,7 +181,7 @@ export default class StructuralMetadataUtils {
       let grandParentDiv = this.getParentItem(parent, clonedItems);
       // A first/last child of siblings, or an only child
       if (grandParentDiv !== null) {
-        let siblingTimespans = this.getItemsOfType('span', siblings);
+        let siblingTimespans = this.getItemsOfType(['span'], siblings);
         let timespanIndex = siblingTimespans.map((sibling) => sibling.id).indexOf(dragSource.id);
 
         let parentIndex = grandParentDiv.items.map((item) => item.id).indexOf(parent.id);
@@ -374,16 +374,20 @@ export default class StructuralMetadataUtils {
 
   /**
    * Get all items in data structure of type 'div' or 'span'
+   * @param {Array} itemTypes types of items to pick
    * @param {Array} json
    * @returns {Array} - all stripped down objects of type in the entire structured metadata collection
    */
-  getItemsOfType(type = 'div', items = []) {
+  getItemsOfType(itemTypes = [], items = []) {
+    if (itemTypes.length === 0) {
+      return [];
+    }
     let options = [];
 
     // Recursive function to search the whole data structure
     let getItems = (items) => {
       for (let item of items) {
-        if (item.type === type) {
+        if (itemTypes.includes(item.type)) {
           let currentObj = { ...item };
           // Keep items array to identify parent timespans in HeadingForm
           if (item.type != 'span') { delete currentObj.items; }
@@ -456,11 +460,7 @@ export default class StructuralMetadataUtils {
     }
 
     const { before, after } = wrapperSpans;
-    const allPossibleParents = this.getItemsOfType('root', allItems).concat(
-      this.getItemsOfType('div', allItems)
-    ).concat(
-      this.getItemsOfType('span', allItems)
-    );
+    const allPossibleParents = this.getItemsOfType(['root', 'div', 'span'], allItems);
 
     // Explore possible headings traversing outwards from a suggested heading
     let exploreOutwards = (heading) => {
@@ -506,9 +506,7 @@ export default class StructuralMetadataUtils {
       } else {
         divsBefore = wrapperParent.items.filter((item, i) => i < spanIndex);
       }
-      const allParents = this.getItemsOfType('div', divsAfter.concat(divsBefore)).concat(
-        this.getItemsOfType('span', divsAfter.concat(divsBefore))
-      );
+      const allParents = this.getItemsOfType(['div', 'span'], [...divsAfter, ...divsBefore]);
       return allParents;
     };
 
@@ -681,7 +679,7 @@ export default class StructuralMetadataUtils {
     };
 
     if (parentItem) {
-      const allSpans = this.getItemsOfType('span', allItems);
+      const allSpans = this.getItemsOfType(['span'], allItems);
       const { before, after } = this.findWrapperSpans(spanObj, allSpans);
       if (before) {
         let siblingBefore = getParentOfSpan(before);

--- a/src/services/__test__/StructuralMetadataUtils.test.js
+++ b/src/services/__test__/StructuralMetadataUtils.test.js
@@ -206,7 +206,7 @@ describe('StructuralMetadataUtils class', () => {
   describe('findWrapperSpans(), ', () => {
     let allSpans = [];
     beforeEach(() => {
-      allSpans = smu.getItemsOfType('span', testData);
+      allSpans = smu.getItemsOfType(['span'], testData);
     });
     test('for first timespan', () => {
       const obj = {
@@ -337,87 +337,77 @@ describe('StructuralMetadataUtils class', () => {
   });
 
   describe('getItemsOfType()', () => {
-    test('type === div', () => {
-      const allDivs = [
-        {
-          type: 'div',
-          label: 'Title',
-          id: '123a-456b-789c-0d',
-        },
-        {
-          type: 'div',
-          label: 'First segment',
-          id: '123a-456b-789c-1d',
-        },
-        {
-          type: 'div',
-          label: 'Sub-Segment 1.1',
-          id: '123a-456b-789c-2d',
-        },
-        {
-          type: 'div',
-          label: 'Second segment',
-          id: '123a-456b-789c-5d',
-        },
-        {
-          type: 'div',
-          label: 'Sub-Segment 2.1',
-          id: '123a-456b-789c-6d',
-        },
-        {
-          type: 'div',
-          label: 'Sub-Segment 2.1.1',
-          id: '123a-456b-789c-7d',
-        },
-      ];
-      const value = smu.getItemsOfType('div', testData);
-      expect(value).toHaveLength(allDivs.length);
-      expect(value).toContainEqual({
-        type: 'div',
-        label: 'Sub-Segment 2.1',
-        id: '123a-456b-789c-6d',
-      });
-    });
-    test('type === span', () => {
-      const allSpans = [
-        {
-          type: 'span',
-          label: 'Segment 1.1',
-          id: '123a-456b-789c-3d',
-          begin: '00:00:03.321',
-          end: '00:00:10.321',
-          valid: true,
-          timeRange: { start: 3.321, end: 10.321 }
-        },
-        {
-          type: 'span',
-          label: 'Segment 1.2',
-          id: '123a-456b-789c-4d',
-          begin: '00:00:11.231',
-          end: '00:08:00.001',
-          valid: true,
-          timeRange: { start: 11.231, end: 480.001 }
-        },
-        {
-          type: 'span',
-          label: 'Segment 2.1',
-          id: '123a-456b-789c-8d',
-          begin: '00:09:03.241',
-          end: '00:15:00.001',
-          valid: true,
-          timeRange: { start: 543.241, end: 900.001 }
-        },
-      ];
-      const value = smu.getItemsOfType('span', testData);
-      expect(value).toHaveLength(allSpans.length);
-      expect(value).toContainEqual({
-        type: 'span',
-        label: 'Segment 2.1',
-        id: '123a-456b-789c-8d',
-        begin: '00:09:03.241',
-        end: '00:15:00.001',
+    const allDivs = [
+      { type: 'div', label: 'Title', id: '123a-456b-789c-0d' },
+      { type: 'div', label: 'First segment', id: '123a-456b-789c-1d' },
+      { type: 'div', label: 'Sub-Segment 1.1', id: '123a-456b-789c-2d' },
+      { type: 'div', label: 'Second segment', id: '123a-456b-789c-5d' },
+      { type: 'div', label: 'Sub-Segment 2.1', id: '123a-456b-789c-6d' },
+      { type: 'div', label: 'Sub-Segment 2.1.1', id: '123a-456b-789c-7d' },
+    ];
+    const allSpans = [
+      {
+        type: 'span', label: 'Segment 1.1', id: '123a-456b-789c-3d',
+        begin: '00:00:03.321', end: '00:00:10.321',
+        valid: true,
+        timeRange: { start: 3.321, end: 10.321 }
+      },
+      {
+        type: 'span', label: 'Segment 1.2', id: '123a-456b-789c-4d',
+        begin: '00:00:11.231', end: '00:08:00.001',
+        valid: true,
+        timeRange: { start: 11.231, end: 480.001 }
+      },
+      {
+        type: 'span', label: 'Segment 2.1', id: '123a-456b-789c-8d',
+        begin: '00:09:03.241', end: '00:15:00.001',
         valid: true,
         timeRange: { start: 543.241, end: 900.001 }
+      },
+    ];
+    test('itemTypes = []', () => {
+      const value = smu.getItemsOfType([], testData);
+      expect(value).toEqual([]);
+    });
+
+    test('itemTypes = [\'root\']', () => {
+      const value = smu.getItemsOfType(['root'], testData);
+      expect(value).toHaveLength(1);
+      expect(value).toContainEqual({
+        type: 'root', label: 'Ima Title', id: '123a-456b-789c-0d'
+      });
+    });
+
+    test('itemTypes = [\'div\']', () => {
+      const value = smu.getItemsOfType(['div'], testData);
+      expect(value).toHaveLength(allDivs.length);
+      expect(value).toContainEqual({
+        type: 'div', label: 'Sub-Segment 2.1', id: '123a-456b-789c-6d'
+      });
+    });
+
+    test('itemTypes = [\'span\']', () => {
+      const value = smu.getItemsOfType(['span'], testData);
+      expect(value).toHaveLength(allSpans.length);
+      expect(value).toContainEqual({
+        type: 'span', label: 'Segment 2.1', id: '123a-456b-789c-8d',
+        begin: '00:09:03.241', end: '00:15:00.001',
+        valid: true,
+        timeRange: { start: 543.241, end: 900.001 }
+      });
+    });
+
+    test('itemTypes = [\'div\', \'span\']', () => {
+      const value = smu.getItemsOfType(['span', 'div'], testData);
+      expect(value).toHaveLength(allSpans.length + allDivs.length);
+      expect(value).toContainEqual({
+        type: 'span', label: 'Segment 2.1', id: '123a-456b-789c-8d',
+        begin: '00:09:03.241', end: '00:15:00.001',
+        valid: true,
+        timeRange: { start: 543.241, end: 900.001 }
+      });
+      expect(value).toContainEqual({
+        type: 'div', label: 'Sub-Segment 2.1', id: '123a-456b-789c-6d'
       });
     });
   });
@@ -1103,7 +1093,7 @@ describe('StructuralMetadataUtils class', () => {
         smu.determineDropTargets(dragSource, nestedTestSmData);
 
         // getItemsOfType() was called with parent scope for the nested timespan
-        expect(getItemsOfTypeSpy).toHaveBeenCalledWith('span', [parentTimespan]);
+        expect(getItemsOfTypeSpy).toHaveBeenCalledWith(['span'], [parentTimespan]);
         // Clear mock
         getItemsOfTypeSpy.mockRestore();
       });

--- a/src/services/sme-hooks.js
+++ b/src/services/sme-hooks.js
@@ -29,7 +29,7 @@ export const useFindNeighborSegments = ({ segment }) => {
   const nextSiblingRef = useRef(null);
 
   const allSpans = useMemo(() => {
-    return structuralMetadataUtils.getItemsOfType('span', smData);
+    return structuralMetadataUtils.getItemsOfType(['span'], smData);
   }, [smData]);
 
   useEffect(() => {
@@ -116,7 +116,7 @@ export const useFindNeighborTimespans = ({ item }) => {
       prevSiblingRef.current = currentIndex > 0 ? siblings[currentIndex - 1] : null;
       nextSiblingRef.current = currentIndex < siblings.length - 1 ? siblings[currentIndex + 1] : null;
     } else if (item) {
-      const siblings = structuralMetadataUtils.getItemsOfType('span', smData);
+      const siblings = structuralMetadataUtils.getItemsOfType(['span'], smData);
       const currentIndex = siblings.findIndex(sibling => sibling.id === item.id);
 
       prevSiblingRef.current = currentIndex > 0 ? siblings[currentIndex - 1] : null;


### PR DESCRIPTION
This PR adds support for creating heading items inside parent timespans. This was missed in the original implementation for nested structure creation, #245 