### PR TITLE
Show heading inside timespan as a possible parent for a new child timespan

### DIFF
--- a/src/components/TimespanForm.js
+++ b/src/components/TimespanForm.js
@@ -66,11 +66,9 @@ const TimespanForm = ({
     // Build wrapperSpans from sibling timespans
     let wrapperSpans = { before: prevSiblingRef.current, after: nextSiblingRef.current };
 
-    // Possible parent timespan that can fully contain the new span
-    let parentTimespan = parentTimespanRef.current ? [parentTimespanRef.current] : [];
-
     // Get all valid div headings and potential parent timespans
-    let validHeadings = structuralMetadataUtils.getValidParents(newSpan, wrapperSpans, smData, parentTimespan);
+    let validHeadings = structuralMetadataUtils
+      .getValidParents(newSpan, wrapperSpans, smData, parentTimespanRef.current);
 
     // Update state with valid headings
     setValidHeadings(validHeadings);

--- a/src/components/__tests__/ButtonSection.test.js
+++ b/src/components/__tests__/ButtonSection.test.js
@@ -271,7 +271,15 @@ describe('ButtonSection component', () => {
               current: {
                 type: 'span', label: 'Segment 1.2', id: '123a-456b-789c-4d',
                 begin: '00:00:11.231', end: '00:08:00.001', valid: true,
-                timeRange: { start: 11.231, end: 480.001 }
+                timeRange: { start: 11.231, end: 480.001 },
+                items: [
+                  { type: 'div', label: 'Sub-Segment 2.1.1', id: '123a-456b-789c-7d' },
+                  {
+                    type: 'span', label: 'Segment 2.1', id: '123a-456b-789c-8d',
+                    begin: '00:09:03.241', end: '00:15:00.001',
+                    valid: true, timeRange: { start: 543.241, end: 900.001 }
+                  }
+                ]
               },
             }
           }));
@@ -323,7 +331,15 @@ describe('ButtonSection component', () => {
               current: {
                 type: 'span', label: 'Segment 1.2', id: '123a-456b-789c-4d',
                 begin: '00:00:11.231', end: '00:08:00.001', valid: true,
-                timeRange: { start: 11.231, end: 480.001 }
+                timeRange: { start: 11.231, end: 480.001 },
+                items: [
+                  { type: 'div', label: 'Sub-Segment 2.1.1', id: '123a-456b-789c-7d' },
+                  {
+                    type: 'span', label: 'Segment 2.1', id: '123a-456b-789c-8d',
+                    begin: '00:09:03.241', end: '00:15:00.001',
+                    valid: true, timeRange: { start: 543.241, end: 900.001 }
+                  }
+                ]
               },
             }
           }));

--- a/src/components/__tests__/TimespanForm.test.js
+++ b/src/components/__tests__/TimespanForm.test.js
@@ -206,7 +206,7 @@ describe('Timespan component', () => {
               current: {
                 type: 'span', label: 'Segment 1.1', id: '123a-456b-789c-3d',
                 begin: '00:00:03.321', end: '00:00:10.321', valid: true,
-                timeRange: { start: 3.321, end: 10.321 }
+                timeRange: { start: 3.321, end: 10.321 }, items: []
               }
             }
           }));
@@ -412,7 +412,7 @@ describe('Timespan component', () => {
               current: {
                 type: 'span', label: 'Segment 1.1', id: '123a-456b-789c-3d',
                 begin: '00:00:03.321', end: '00:00:10.321', valid: true,
-                timeRange: { start: 3.321, end: 10.321 }
+                timeRange: { start: 3.321, end: 10.321 }, items: []
               }
             }
           }));
@@ -429,25 +429,13 @@ describe('Timespan component', () => {
         test('when begin time is within an existing timespan', () => {
           // Update the neighbor timespan relationships
           jest.spyOn(hooks, 'useFindNeighborSegments').mockImplementation(() => ({
-            prevSiblingRef: {
-              current: {
-                type: 'span', label: 'Segment 2.1.1', id: '123a-456b-789c-7d',
-                begin: '00:09:10.241', end: '00:10:00.321', valid: true,
-                timeRange: { start: 550.241, end: 660.321 }
-              }
-            },
-            nextSiblingRef: {
-              current: {
-                type: 'span', label: 'Segment 2.1.2', id: '123a-456b-789c-8d',
-                begin: '00:12:00.231', end: '00:13:00.001', valid: true,
-                timeRange: { start: 720.231, end: 790.001 }
-              }
-            },
+            prevSiblingRef: { current: { type: 'span', label: 'Segment 2.1.1', id: '123a-456b-789c-7d' } },
+            nextSiblingRef: { current: { type: 'span', label: 'Segment 2.1.2', id: '123a-456b-789c-8d' } },
             parentTimespanRef: {
               current: {
                 type: 'span', label: 'Segment 2.1', id: '123a-456b-789c-6d',
-                begin: '00:09:00.241', end: '00:15:00.001', valid: true,
-                timeRange: { start: 540.241, end: 900.001 },
+                items: [{ type: 'span', label: 'Segment 2.1.1', id: '123a-456b-789c-7d' },
+                { type: 'span', label: 'Segment 2.1.2', id: '123a-456b-789c-8d' }]
               }
             }
           }));
@@ -521,7 +509,7 @@ describe('Timespan component', () => {
     });
   });
 
-  test('with parent element selection', () => {
+  test('changes form state with parent element selection', () => {
     jest.spyOn(hooks, 'useFindNeighborSegments').mockImplementation(() => ({
       prevSiblingRef: { current: null },
       nextSiblingRef: {

--- a/src/services/__test__/StructuralMetadataUtils.test.js
+++ b/src/services/__test__/StructuralMetadataUtils.test.js
@@ -543,131 +543,121 @@ describe('StructuralMetadataUtils class', () => {
         id: '123a-456b-789c-1d',
       });
     });
-    test('when wrapped by existing timespans', () => {
+
+    test('when new timespan is wrapped by existing timespans', () => {
       const newSpan = { begin: '00:08:00.001', end: '00:09:00.001' };
       const wrapperSpans = {
-        before: {
-          type: 'span',
-          label: 'Segment 1.2',
-          id: '123a-456b-789c-4d',
-          begin: '00:00:11.231',
-          end: '00:08:00.001',
-        },
-        after: {
-          type: 'span',
-          label: 'Segment 2.1',
-          id: '123a-456b-789c-8d',
-          begin: '00:09:03.241',
-          end: '00:15:00.001',
-        },
+        before: { type: 'span', label: 'Segment 1.2', id: '123a-456b-789c-4d' },
+        after: { type: 'span', label: 'Segment 2.1', id: '123a-456b-789c-8d' },
       };
       const expected = [
-        {
-          type: 'div',
-          label: 'First segment',
-          id: '123a-456b-789c-1d',
-        },
-        {
-          type: 'div',
-          label: 'Second segment',
-          id: '123a-456b-789c-5d',
-        },
-        {
-          type: 'div',
-          label: 'Sub-Segment 2.1',
-          id: '123a-456b-789c-6d',
-        },
-        {
-          type: 'div',
-          label: 'Sub-Segment 2.1.1',
-          id: '123a-456b-789c-7d',
-        },
+        { type: 'div', label: 'First segment', id: '123a-456b-789c-1d' },
+        { type: 'div', label: 'Second segment', id: '123a-456b-789c-5d' },
+        { type: 'div', label: 'Sub-Segment 2.1', id: '123a-456b-789c-6d' },
+        { type: 'div', label: 'Sub-Segment 2.1.1', id: '123a-456b-789c-7d' },
       ];
       const value = smu.getValidParents(newSpan, wrapperSpans, testData);
       expect(value).toHaveLength(expected.length);
-      expect(value).toContainEqual({
-        type: 'div',
-        label: 'Sub-Segment 2.1',
-        id: '123a-456b-789c-6d',
-      });
+      expect(value).toContainEqual({ type: 'div', label: 'Sub-Segment 2.1', id: '123a-456b-789c-6d' });
     });
-    test('when there are no timespans after', () => {
+
+    test('when there are no timespans after the new timespan', () => {
       const newSpan = { begin: '00:15:00.001', end: '00:16:00.001' };
       const wrapperSpans = {
-        before: {
-          type: 'span',
-          label: 'Segment 2.1',
-          id: '123a-456b-789c-8d',
-          begin: '00:09:03.241',
-          end: '00:15:00.001',
-        },
+        before: { type: 'span', label: 'Segment 2.1', id: '123a-456b-789c-8d' },
         after: null,
       };
       const expected = [
-        {
-          type: 'div',
-          label: 'Title',
-          id: '123a-456b-789c-0d',
-        },
-        {
-          type: 'div',
-          label: 'Second segment',
-          id: '123a-456b-789c-5d',
-        },
-        {
-          type: 'div',
-          label: 'Sub-Segment 2.1',
-          id: '123a-456b-789c-6d',
-        },
-        {
-          type: 'div',
-          label: 'A ',
-          id: '123a-456b-789c-9d',
-        },
+        { type: 'div', label: 'Title', id: '123a-456b-789c-0d' },
+        { type: 'div', label: 'Second segment', id: '123a-456b-789c-5d' },
+        { type: 'div', label: 'Sub-Segment 2.1', id: '123a-456b-789c-6d' },
+        { type: 'div', label: 'A ', id: '123a-456b-789c-9d' },
       ];
       const value = smu.getValidParents(newSpan, wrapperSpans, testData);
       expect(value).toHaveLength(expected.length);
-      expect(value).toContainEqual({
-        type: 'div',
-        label: 'Sub-Segment 2.1',
-        id: '123a-456b-789c-6d',
-      });
+      expect(value).toContainEqual({ type: 'div', label: 'Sub-Segment 2.1', id: '123a-456b-789c-6d' });
     });
-    test('when there are no timespans before', () => {
+
+    test('when there are no timespans before the new timespan', () => {
       const newSpan = { begin: '00:00:00.000', end: '00:00:03.321' };
       const wrapperSpans = {
         before: null,
-        after: {
-          type: 'span',
-          label: 'Act 1',
-          id: '123a-456b-789c-3d',
-          begin: '00:00:03.321',
-          end: '00:00:10.321',
-        },
+        after: { type: 'span', label: 'Act 1', id: '123a-456b-789c-3d' },
       };
       const expected = [
-        {
-          type: 'div',
-          label: 'Title',
-          id: '123a-456b-789c-0d',
-        },
-        {
-          type: 'div',
-          label: 'First segment',
-          id: '123a-456b-789c-1d',
-        },
-        {
-          type: 'div',
-          label: 'Sub-Segment 1.1',
-          id: '123a-456b-789c-2d',
-        },
+        { type: 'div', label: 'Title', id: '123a-456b-789c-0d' },
+        { type: 'div', label: 'First segment', id: '123a-456b-789c-1d' },
+        { type: 'div', label: 'Sub-Segment 1.1', id: '123a-456b-789c-2d' },
       ];
       const value = smu.getValidParents(newSpan, wrapperSpans, testData);
       expect(value).toHaveLength(expected.length);
-      expect(value).toContainEqual({
-        type: 'div',
-        label: 'Sub-Segment 1.1',
-        id: '123a-456b-789c-2d',
+      expect(value).toContainEqual({ type: 'div', label: 'Sub-Segment 1.1', id: '123a-456b-789c-2d' });
+    });
+
+    describe('when new timespan has a parent timespan', () => {
+      test('without sibling headings', () => {
+        const parentTimespan = nestedTestSmData[0].items[1].items[0].items[0];
+        const newSpan = { begin: '00:10:00.321', end: '00:11:00.321' };
+        const wrapperSpans = {
+          before: { type: 'span', label: 'Segment 2.1.1', id: '123a-456b-789c-7d' },
+          after: { type: 'span', label: 'Segment 2.1.2', id: '123a-456b-789c-8d' },
+        };
+
+        const value = smu.getValidParents(newSpan, wrapperSpans, nestedTestSmData, parentTimespan);
+        expect(value).toHaveLength(1);
+        expect(value.map(h => h.id)).toContain('123a-456b-789c-6d');
+      });
+
+      describe('with a sibling heading', () => {
+        // Get a copy of the parent timeppan to modify as needed
+        const parentTimespan = cloneDeep(nestedTestSmData[0].items[1].items[0].items[0]);
+        beforeEach(() => {
+          parentTimespan.items.splice(0, 0, {
+            type: 'div', label: 'New Sub-segment Title Before', id: 'new-title-before',
+          });
+        });
+
+        test('next to the new timespan', () => {
+          const newSpan = { begin: '00:09:00.241', end: '00:09:10.241' };
+          const wrapperSpans = {
+            before: null,
+            after: { type: 'span', label: 'Segment 2.1.1', id: '123a-456b-789c-7d' }
+          };
+
+          const value = smu.getValidParents(newSpan, wrapperSpans, nestedTestSmData, parentTimespan);
+          expect(value).toHaveLength(2);
+          // Have both parent and sibling heading as valid parents
+          expect(value.map(h => h.id)).toContain('123a-456b-789c-6d');
+          expect(value.map(h => h.id)).toContain('new-title-before');
+        });
+
+        test('before previous sibling timespan (out of order)', () => {
+          const newSpan = { begin: '00:10:00.321', end: '00:11:00.321' };
+          const wrapperSpans = {
+            before: { type: 'span', label: 'Segment 2.1.1', id: '123a-456b-789c-7d' },
+            after: { type: 'span', label: 'Segment 2.1.2', id: '123a-456b-789c-8d' },
+          };
+
+          const value = smu.getValidParents(newSpan, wrapperSpans, nestedTestSmData, parentTimespan);
+          // Only have the parent timespan as a valid parent
+          expect(value).toHaveLength(1);
+          expect(value.map(h => h.id)).toContain('123a-456b-789c-6d');
+        });
+
+        test('after next sibling timespan (out of order)', () => {
+          const newSpan = { begin: '00:10:00.321', end: '00:11:00.321' };
+          const wrapperSpans = {
+            before: { type: 'span', label: 'Segment 2.1.1', id: '123a-456b-789c-7d' },
+            after: { type: 'span', label: 'Segment 2.1.2', id: '123a-456b-789c-8d' },
+          };
+          // Add a title item to the end of the children list
+          parentTimespan.items.push({ type: 'div', label: 'New Sub-segment Title After', id: 'new-title-after' });
+
+          const value = smu.getValidParents(newSpan, wrapperSpans, nestedTestSmData, parentTimespan);
+          // Only have parent timespan as a valid parent
+          expect(value).toHaveLength(1);
+          expect(value.map(h => h.id)).toContain('123a-456b-789c-6d');
+        });
       });
     });
   });


### PR DESCRIPTION
Add support for selecting a nested heading inside a timespan, when a new child timespan is created. This use-case was missed in the previous related work, relevant comment in previous PR: https://github.com/avalonmediasystem/react-structural-metadata-editor/pull/249#pullrequestreview-3212131597

Related work: https://github.com/avalonmediasystem/react-structural-metadata-editor/pull/249 and #245 