### PR TITLE
Fix broken nested timespan creation

### DIFF
--- a/src/components/__tests__/TimespanForm.test.js
+++ b/src/components/__tests__/TimespanForm.test.js
@@ -13,6 +13,7 @@ const tempSegment = {
   id: 'temp-segment',
   editable: true,
   color: '#FBB040',
+  parentId: null,
 };
 
 // Set up a redux store for the tests

--- a/src/services/StructuralMetadataUtils.js
+++ b/src/services/StructuralMetadataUtils.js
@@ -912,7 +912,6 @@ export default class StructuralMetadataUtils {
    */
   calculateAdjacentTimespans(smData, item) {
     const allSpans = this.getItemsOfType(['span'], smData);
-    // const otherSpans = allSpans.filter((span) => span.id != item.id);
 
     let possibleParent = null;
     let closestGapBefore = Infinity; let possiblePrevSibling = null;
@@ -920,7 +919,10 @@ export default class StructuralMetadataUtils {
 
     const { start, end } = item.timeRange;
 
-    const parentDiv = this.getParentItem(item, smData);
+    let parentDiv = this.getParentItem(item, smData);
+    if (parentDiv == null && item.parentId != undefined) {
+      parentDiv = this.findItem(item.parentId, smData);
+    }
     if (parentDiv && parentDiv.type === 'span') {
       possibleParent = parentDiv;
     } else {

--- a/src/services/WaveformDataUtils.js
+++ b/src/services/WaveformDataUtils.js
@@ -68,11 +68,11 @@ export default class WaveformDataUtils {
   insertTempSegment(peaksInstance, duration) {
     // Current time of the playhead
     const currentTime = this.roundOff(peaksInstance.player.getCurrentTime());
-
     let rangeBeginTime = currentTime;
+    // Save possible parent's id that corresponds to an element in smData structure
+    let parentId = null;
     // Initially set rangeEndTime to 60 seconds from the current time
     let rangeEndTime = Math.round((currentTime + 60.0) * 1000) / 1000;
-
     // Get all segments in Peaks
     const currentSegments = this.sortSegments(peaksInstance, 'startTime');
 
@@ -173,6 +173,7 @@ export default class WaveformDataUtils {
           if (commonContainer) {
             // Adjust rangeEndTime to not overlap with the children of the common parent segment
             rangeEndTime = findNonOverlappingEndTime(commonContainer, rangeEndTime);
+            parentId = commonContainer._id;
           } else {
             // Adjust rangeEndTime when they don't share a common parent segment
             rangeEndTime = Math.min(rangeEndTime, beginContainers[0].endTime);
@@ -200,6 +201,7 @@ export default class WaveformDataUtils {
         // Suggested range is overlapping with an existing segment at the beginning
         else if (beginContainers.length > 0 && endContainers.length === 0) {
           const containingSegment = beginContainers[0];
+          parentId = containingSegment._id;
           rangeEndTime = findNonOverlappingEndTime(containingSegment, rangeEndTime);
         }
 
@@ -227,6 +229,9 @@ export default class WaveformDataUtils {
           editable: true,
           color: COLOR_PALETTE[2],
           id: 'temp-segment',
+          // Add 'parentId' prop to help identify the parent timespan in next calculations,
+          // as this segment doesn't have a corresponding timespan in the smData structure.
+          parentId,
         });
       }
     }

--- a/src/services/sme-hooks.js
+++ b/src/services/sme-hooks.js
@@ -39,13 +39,14 @@ export const useFindNeighborSegments = ({ segment }) => {
       let item;
       if (segment._id === 'temp-segment') {
         // Construct a span object from segment when handling timespan creation
-        const { _id, _startTime, _endTime } = segment;
+        const { _id, _startTime, _endTime, parentId } = segment;
         item = {
           type: 'span', label: '', id: _id,
           begin: structuralMetadataUtils.toHHmmss(_startTime),
           end: structuralMetadataUtils.toHHmmss(_endTime),
           valid: _startTime < _endTime && _endTime <= duration,
-          timeRange: { start: _startTime, end: _endTime }
+          timeRange: { start: _startTime, end: _endTime },
+          parentId,
         };
       } else {
         // Find the existing span object from smData


### PR DESCRIPTION
Nested timespan creation was broken by the changes made in the work done in the PR (https://github.com/avalonmediasystem/react-structural-metadata-editor/pull/254) for validating empty divs in structure editing. 

This PR fixes this bug and introduces new unit tests to test the neighbor and parent timespan calculation that was broken by the previous changes.

The fix: introduce `parentId` property (this is already calculated by the existing logic) for the `temp-segment`in Peaks instance when creating new timespans. The existing logic for calculating the parent timespan fails because this new segment doesn't have a corresponding timespan in the existing `smData` structure, which returns `null` for the `getParentItem()` function in the neighbor timespan calculation.