### PR TITLE
Fix button styling for Avalon in the text-editor implementation

### DIFF
--- a/src/components/TextEditor.js
+++ b/src/components/TextEditor.js
@@ -155,7 +155,7 @@ const TextEditor = ({ initialJson = null }) => {
           <div className="text-editor-buttons">
             <div className="d-flex mb-2">
               <Button
-                variant="info"
+                variant="outline-secondary"
                 onClick={handleAddHeading}
                 title="Insert heading template at cursor"
                 className="w-100 mx-1 mt-2"
@@ -164,7 +164,7 @@ const TextEditor = ({ initialJson = null }) => {
                 New Heading Template
               </Button>
               <Button
-                variant="info"
+                variant="outline-secondary"
                 onClick={handleAddTimespan}
                 title="Insert timespan template at cursor"
                 className="w-100 mx-1 mt-2"
@@ -185,7 +185,7 @@ const TextEditor = ({ initialJson = null }) => {
                 Save JSON
               </Button>
               <Button
-                variant={copySuccess ? "success" : "secondary"}
+                variant={copySuccess ? "secondary" : "success"}
                 onClick={handleCopy}
                 disabled={!isValid}
                 title="Copy JSON to clipboard"

--- a/src/containers/StructureTabView.js
+++ b/src/containers/StructureTabView.js
@@ -17,14 +17,14 @@ const StructureTabView = ({ disableSave, structureIsSaved, structureURL, showTex
         <div className="view-mode-tabs mb-3 d-flex justify-content-end">
           <ButtonGroup>
             <Button
-              variant={viewMode === 'visual' ? 'primary' : 'outline-primary'}
+              variant={viewMode === 'visual' ? 'primary' : 'outline-secondary'}
               onClick={() => setViewMode('visual')}
               data-testid="visual-editor-button"
             >
               Visual Editor
             </Button>
             <Button
-              variant={viewMode === 'text' ? 'primary' : 'outline-primary'}
+              variant={viewMode === 'text' ? 'primary' : 'outline-secondary'}
               onClick={() => setViewMode('text')}
               data-testid="text-editor-button"
             >

--- a/src/containers/__tests__/StructureTabView.test.js
+++ b/src/containers/__tests__/StructureTabView.test.js
@@ -99,7 +99,7 @@ describe('StructureTabView component', () => {
         { initialState }
       );
       expect(getByTestId('visual-editor-button')).toHaveClass('btn-primary');
-      expect(getByTestId('text-editor-button')).toHaveClass('btn-outline-primary');
+      expect(getByTestId('text-editor-button')).toHaveClass('btn-outline-secondary');
     });
 
     test('switches to text-editor when \'Text Editor\' button is clicked', () => {
@@ -110,12 +110,12 @@ describe('StructureTabView component', () => {
 
       // Initially, Visual Editor button is active
       expect(visualEditorButton).toHaveClass('btn-primary');
-      expect(textEditorButton).toHaveClass('btn-outline-primary');
+      expect(textEditorButton).toHaveClass('btn-outline-secondary');
 
       fireEvent.click(textEditorButton);
 
       // Text Editor button is active
-      expect(visualEditorButton).toHaveClass('btn-outline-primary');
+      expect(visualEditorButton).toHaveClass('btn-outline-secondary');
       expect(textEditorButton).toHaveClass('btn-primary');
 
       // Displays the TextEditor component not the visual components


### PR DESCRIPTION
Related issue: #257 

A couple minor styling changes to the buttons after testing the work in https://github.com/avalonmediasystem/react-structural-metadata-editor/pull/259 in Avalon's SME instance.