### PR TITLE
Add download button for demo site

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,7 @@ A consuming application is expected to provide the following configuration `prop
 | `structureIsSaved` | function | Function to keep track of the status of the structure changes in the editor| Optional |
 | `disableSave` | boolean | Boolean flag to remove `Save Structure` functionality in the UI. Value of this flag defaults to `false`. When saving is disabled in the editor, 'Save Structure' button will not be displayed. | Optional |
 | `showTextEditor` | boolean | Boolean flag to enable display of a text-based editor for the JSON structure. Value of this flag defauls to `false`. When this is enabled a toggle button is displayed to enable to toggle views. | Optional |
+| `enableDownload` | boolean | Boolean flag to show/hide `Download Manifest` functionality in the demo site. Value of this flag defaults to `false`. This allows a user to download the IIIF Manifest with the edited structure from the demo site. This is meant to be used as a replacement for `Save Structure` button in the demo site, because the demo site is not able to facilitate a save end point. _**IMPORTANT** Demo site only displays the structure for the first Canvas in the current implementation._ | Optional |
 
 #### Example usage
 

--- a/demo/src/app.css
+++ b/demo/src/app.css
@@ -7,6 +7,12 @@
   color: #7e7e7e;
 }
 
+/* Remove space between structure and download button */
+.structure-section>.structure-lists {
+    height: fit-content;
+    max-height: 28vh;
+  }
+
 /* Reference: https://loading.io/css/ */
 .loading-app {
   display: inline-block;

--- a/demo/src/app.js
+++ b/demo/src/app.js
@@ -53,6 +53,7 @@ const App = (props) => {
           canvasIndex={0}
           structureIsSaved={(val) => { }}
           disableSave={props.disableSave}
+          enableDownload={props.enableDownload}
           key={manifestUrl}
           showTextEditor={props.showTextEditor}
         />

--- a/demo/src/index.js
+++ b/demo/src/index.js
@@ -10,6 +10,7 @@ const props = {
   canvasIndex: 0,
   structureIsSaved: (val) => { },
   disableSave: true,
+  enableDownload: true,
   showTextEditor: true,
 };
 

--- a/src/App.js
+++ b/src/App.js
@@ -52,6 +52,7 @@ App.defaultProps = {
   structureIsSaved: (val) => { },
   withCredentials: false,
   disableSave: false,
+  enableDownload: false,
 };
 
 App.propTypes = {
@@ -65,6 +66,7 @@ App.propTypes = {
   structureIsSaved: PropTypes.func,
   withCredentials: PropTypes.bool,
   disableSave: PropTypes.bool,
+  enableDownload: PropTypes.bool,
   showTextEditor: PropTypes.bool,
 };
 

--- a/src/containers/StructureOutputContainer.js
+++ b/src/containers/StructureOutputContainer.js
@@ -10,13 +10,14 @@ import { configureAlert } from '../services/alert-status';
 import { setAlert, updateStructureStatus } from '../actions/forms';
 import { isEqual } from 'lodash';
 import StructuralMetadataUtils from '../services/StructuralMetadataUtils';
+import { getLabelValue, parseJSONToStructure } from '../services/iiif-parser';
 
-const StructureOutputContainer = ({ disableSave, structureIsSaved, structureURL }) => {
+const StructureOutputContainer = ({ disableSave, enableDownload, structureIsSaved, structureURL }) => {
   const smu = new StructuralMetadataUtils();
   const apiUtils = new APIUtils();
 
   // State variables from Redux store
-  const { manifestFetched } = useSelector((state) => state.manifest);
+  const { manifestFetched, manifest } = useSelector((state) => state.manifest);
   const { smData, initSmData, smDataIsValid } = useSelector((state) => state.structuralMetadata);
   const { structureInfo, editingDisabled } = useSelector((state) => state.forms);
 
@@ -71,6 +72,25 @@ const StructureOutputContainer = ({ disableSave, structureIsSaved, structureURL 
     }
   };
 
+  const handleDownload = () => {
+    if (!manifest || !smData?.length) return;
+    const updatedManifest = {
+      ...manifest,
+      structures: parseJSONToStructure(manifest, smData, 0),
+    };
+    // Use Manifest name as file name
+    let manifestName = getLabelValue(manifest.label);
+    const json = JSON.stringify(updatedManifest, null, 2);
+    const blob = new Blob([json], { type: 'application/json' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = manifestName == 'Label could not be parsed'
+      ? 'manifest.json' : `${manifestName}.json`;
+    a.click();
+    URL.revokeObjectURL(url);
+  };
+
   return (
     <section
       className="structure-section"
@@ -94,6 +114,20 @@ const StructureOutputContainer = ({ disableSave, structureIsSaved, structureURL 
               className="float-end"
             >
               Save Structure
+            </Button>
+          </Col>
+        </Row>)
+      }
+      {enableDownload && (
+        <Row>
+          <Col className="pt-2">
+            <Button
+              variant="outline-secondary"
+              onClick={handleDownload}
+              data-testid="download-manifest-button"
+              className="float-end"
+            >
+              Download Manifest
             </Button>
           </Col>
         </Row>)

--- a/src/containers/StructureTabView.js
+++ b/src/containers/StructureTabView.js
@@ -6,7 +6,7 @@ import TextEditor from "../components/TextEditor";
 import StructureOutputContainer from "./StructureOutputContainer";
 import ButtonSection from "../components/ButtonSection";
 
-const StructureTabView = ({ disableSave, structureIsSaved, structureURL, showTextEditor = false }) => {
+const StructureTabView = ({ disableSave, enableDownload, structureIsSaved, structureURL, showTextEditor = false }) => {
   const { smData } = useSelector((state) => state.structuralMetadata);
 
   const [viewMode, setViewMode] = useState('visual');
@@ -38,6 +38,7 @@ const StructureTabView = ({ disableSave, structureIsSaved, structureURL, showTex
           <ButtonSection />
           <StructureOutputContainer
             disableSave={disableSave}
+            enableDownload={enableDownload}
             structureIsSaved={structureIsSaved}
             structureURL={structureURL}
           />

--- a/src/services/__test__/iiif-parser.test.js
+++ b/src/services/__test__/iiif-parser.test.js
@@ -6,7 +6,7 @@ import {
   manifestWoChoice,
   manifestWNestedStructure,
   manifestWEmptyRanges,
-  manifestWoStructItems
+  manifestWithSectionCanvas,
 } from '../testing-helpers';
 
 describe('iiif-parser', () => {
@@ -80,8 +80,13 @@ describe('iiif-parser', () => {
   });
 
   describe('getWaveformInfo()', () => {
-    test('when given manifest is invalid', () => {
+    test('when given manifest is undefined', () => {
       const waveform = iiifParser.getWaveformInfo(undefined, 0);
+      expect(waveform).toEqual(null);
+    });
+
+    test('when given manifest is null', () => {
+      const waveform = iiifParser.getWaveformInfo(null, 0);
       expect(waveform).toEqual(null);
     });
 
@@ -119,25 +124,29 @@ describe('iiif-parser', () => {
       expect(items.length).toBe(0);
     });
 
-    test('omits root element with behavior: \'top\'', () => {
-      const structureJSON = iiifParser.parseStructureToJSON(manifestWithStructure, 660);
-      expect(structureJSON.length).toEqual(1);
+    describe('parses structures with root Range with behavior=\'top\'', () => {
+      test('and omits root Range', () => {
+        const structureJSON = iiifParser.parseStructureToJSON(manifestWithStructure, 660);
+        expect(structureJSON.length).toEqual(1);
 
-      const { type, label, items } = structureJSON[0];
-      expect(label).toEqual('Volleyball for Boys');
-      expect(type).toEqual('div');
-      expect(items.length).toBe(1);
-    });
+        const { type, label, items } = structureJSON[0];
+        // Has the label of the first section at the root level
+        expect(label).not.toBe(null);
+        expect(label).toEqual('Volleyball for Boys');
+        expect(type).toEqual('div');
+        expect(items.length).toBe(1);
+      });
 
-    test('returns corrrect structure in a multi-canvas manifest', () => {
-      const structureJSON = iiifParser.parseStructureToJSON(manifestWithStructure, 660, 1);
-      expect(structureJSON.length).toEqual(1);
+      test('and returns structure for the current Canvas', () => {
+        const structureJSON = iiifParser.parseStructureToJSON(manifestWithStructure, 660, 1);
+        expect(structureJSON.length).toEqual(1);
 
-      const { type, label, items } = structureJSON[0];
-      expect(label).toEqual('Lunchroom Manners');
-      expect(type).toEqual('div');
-      expect(items.length).toBe(2);
-      expect(items[0].label).toBe('Introduction');
+        const { type, label, items } = structureJSON[0];
+        expect(label).toEqual('Lunchroom Manners');
+        expect(type).toEqual('div');
+        expect(items.length).toBe(2);
+        expect(items[0].label).toBe('Introduction');
+      });
     });
 
     test('builds structure for childless divs', () => {
@@ -279,15 +288,31 @@ describe('iiif-parser', () => {
       expect(invalidRange.items).toEqual([]);
     });
 
-    test('handles structures with undefined items property', () => {
-      const structureJSON = iiifParser.parseStructureToJSON(manifestWoStructItems, 500);
-      expect(structureJSON.length).toEqual(1);
+    describe('correctly identifies section items', () => {
+      test('with Canvas reference in structures', () => {
+        const structureJSON = iiifParser.parseStructureToJSON(manifestWithSectionCanvas, 660, 1);
+        expect(structureJSON.length).toEqual(1);
 
-      const root = structureJSON[0];
-      expect(root.items.length).toBe(1);
-      expect(root.items[0].label).toEqual('Valid Range');
-      expect(root.items[0].type).toEqual('div');
-      expect(root.items[0].items).toEqual([]);
+        const root = structureJSON[0];
+        expect(root.label).toEqual('Media 2');
+        expect(root.type).toEqual('div');
+        expect(root.items).toHaveLength(0);
+        expect(root.isCanvasSection).toBeTruthy();
+        expect(root.nestedSpan).toBeFalsy();
+      });
+
+      test('without Canvas reference in structures', () => {
+        const structureJSON = iiifParser.parseStructureToJSON(manifestWithStructure, 660, 1);
+        expect(structureJSON.length).toEqual(1);
+
+        const root = structureJSON[0];
+        expect(root.label).toEqual('Lunchroom Manners');
+        expect(root.type).toEqual('div');
+        expect(root.isCanvasSection).toBeFalsy();
+        expect(root.items).toHaveLength(2);
+        expect(root.items[0].label).toBe('Introduction');
+        expect(root.items[1].label).toBe('Washing Hands');
+      });
     });
   });
 
@@ -325,6 +350,405 @@ describe('iiif-parser', () => {
     test('returns \'Label could not be parsed\' for null/undefined labels', () => {
       expect(iiifParser.getLabelValue(null)).toBe('Label could not be parsed');
       expect(iiifParser.getLabelValue(undefined)).toBe('Label could not be parsed');
+    });
+  });
+
+  describe('parseJSONToStructure()', () => {
+    describe('returns original structures from Manifest', () => {
+      test('when smData is empty', () => {
+        const structures = iiifParser.parseJSONToStructure(manifest, [], 0);
+        expect(structures).toEqual(manifest.structures);
+      });
+      test('when smData is undefined', () => {
+        const structures = iiifParser.parseJSONToStructure(manifest, undefined, 0);
+        expect(structures).toEqual(manifest.structures);
+      });
+      test('when smData is undefined', () => {
+        const structures = iiifParser.parseJSONToStructure(manifest, null, 0);
+        expect(structures).toEqual(manifest.structures);
+      });
+    });
+
+    test('returns [] when both smData and manifest are undefined', () => {
+      const structures = iiifParser.parseJSONToStructure(undefined, undefined, 0);
+      expect(structures).toEqual([]);
+    });
+
+    describe('parses structures with sections with Canvas reference and', () => {
+      const sectionSmData = [
+        {
+          type: 'root', label: 'Media 2 - Edited', nestedSpan: false, id: '1', items: [],
+          isCanvasSection: true,
+        }
+      ];
+      const manifestId = 'http://example.com/canvas-ranges/manifest';
+      const canvasId = 'http://example.com/canvas-ranges/canvas/2';
+      const otherCanvasId = 'http://example.com/canvas-ranges/canvas/1';
+
+      test('preserves root element without \'top\' behavior in structures', () => {
+        const ogRootRange = manifestWithSectionCanvas.structures[0];
+        expect(ogRootRange.label).toStrictEqual({ 'en': ['Root'] });
+
+        const structures = iiifParser.parseJSONToStructure(manifestWithSectionCanvas, sectionSmData, 1);
+        const editedRootRange = structures[0];
+        expect(editedRootRange.behavior).not.toBe('top');
+        expect(editedRootRange.label).toStrictEqual({ 'en': ['Root'] });
+      });
+
+      test('updates Range labels for edited structure items', () => {
+        const ogSecondSection = manifestWithSectionCanvas.structures[0].items[1];
+        expect(ogSecondSection.label).toStrictEqual({ 'en': ['Media 2'] });
+
+        const structures = iiifParser.parseJSONToStructure(manifestWithSectionCanvas, sectionSmData, 1);
+        const editedRootRange = structures[0];
+        expect(editedRootRange.items.length).toBe(2);
+        expect(editedRootRange.items[1].label).toStrictEqual({ 'en': ['Media 2 - Edited'] });
+      });
+
+      test('preserves Range labels for structure items in other canvases', () => {
+        const structures = iiifParser.parseJSONToStructure(manifestWithSectionCanvas, sectionSmData, 1);
+        const editedRootRange = structures[0];
+        expect(editedRootRange.items.length).toBe(2);
+
+        expect(editedRootRange.items[0].label).toStrictEqual({ 'en': ['Media'] });
+      });
+
+      test('builds Canvas references for edited section items', () => {
+        const ogSecondSection = manifestWithSectionCanvas.structures[0].items[1];
+        expect(ogSecondSection.label).toStrictEqual({ 'en': ['Media 2'] });
+        expect(ogSecondSection.items.length).toBe(1);
+        expect(ogSecondSection.items[0].type).toBe('Canvas');
+        expect(ogSecondSection.items[0].id).toBe(`${canvasId}#t=0,660`);
+
+        const structures = iiifParser.parseJSONToStructure(manifestWithSectionCanvas, sectionSmData, 1);
+
+        const editedRootRange = structures[0];
+        expect(editedRootRange.items.length).toBe(2);
+
+        const editedSecondSection = editedRootRange.items[1];
+        expect(editedSecondSection.items.length).toBe(1);
+        expect(editedSecondSection.items[0].type).toBe('Canvas');
+        expect(editedSecondSection.items[0].id).toBe(`${canvasId}#t=0,660`);
+      });
+
+      test('preserves Canvas references for other section items', () => {
+        const ogFirstSection = manifestWithSectionCanvas.structures[0].items[0];
+        expect(ogFirstSection.label).toStrictEqual({ 'en': ['Media'] });
+        expect(ogFirstSection.items.length).toBe(1);
+        expect(ogFirstSection.items[0].type).toBe('Canvas');
+        expect(ogFirstSection.items[0].id).toBe(`${otherCanvasId}#t=0,500`);
+
+        const structures = iiifParser.parseJSONToStructure(manifestWithSectionCanvas, sectionSmData, 1);
+
+        const editedRootRange = structures[0];
+        expect(editedRootRange.items.length).toBe(2);
+
+        const firstSection = editedRootRange.items[0];
+        expect(firstSection.items.length).toBe(1);
+        expect(firstSection.items[0].type).toBe('Canvas');
+        expect(firstSection.items[0].id).toBe(`${otherCanvasId}#t=0,500`);
+      });
+
+      test('assigns hierarchical Range ids at each level', () => {
+        const structures = iiifParser.parseJSONToStructure(manifestWithSectionCanvas, sectionSmData, 1);
+
+        const rootRange = structures[0];
+        expect(rootRange.id).toBe(`${manifestId}/range/0`);
+
+        const firstSection = rootRange.items[0];
+        expect(firstSection.id).toBe(`${manifestId}/range/1`);
+
+        const secondSection = rootRange.items[1];
+        expect(secondSection.id).toBe(`${manifestId}/range/2`);
+      });
+
+      test('does not include internal smData properties in structures', () => {
+        const structures = iiifParser.parseJSONToStructure(manifestWithSectionCanvas, sectionSmData, 1);
+
+        const editedRootRange = structures[0];
+        const firstSection = editedRootRange.items[0];
+        const secondSection = editedRootRange.items[1];
+
+        [editedRootRange, firstSection, secondSection].forEach(range => {
+          expect(range).not.toHaveProperty('nestedSpan');
+          expect(range).not.toHaveProperty('timeRange');
+          expect(range).not.toHaveProperty('begin');
+          expect(range).not.toHaveProperty('end');
+          expect(range).not.toHaveProperty('valid');
+          expect(range).not.toHaveProperty('isCanvasSection');
+        });
+      });
+
+      test('all Range ids are unique in structures', () => {
+        const structures = iiifParser.parseJSONToStructure(manifestWithSectionCanvas, sectionSmData, 1);
+        const allIds = [];
+        const collect = (items) => {
+          for (const item of items ?? []) {
+            if (item.id) allIds.push(item.id);
+            if (Array.isArray(item.items)) collect(item.items);
+          }
+        };
+        collect(structures);
+        expect(new Set(allIds).size).toBe(allIds.length);
+      });
+    });
+
+    describe('parses normal structures and', () => {
+      const smData = [
+        {
+          type: 'div', label: 'Volleyball for Boys - First Section', nestedSpan: false, id: '1',
+          items: [
+            {
+              label: 'Volleyball for Boys - Introduction', timeRange: { start: 0, end: 2.37 }, id: '2',
+              items: [], type: 'span', nestedSpan: false, begin: '00:00:00.000', end: '00:02:37.000'
+            }
+          ]
+        }
+      ];
+      const manifestId = 'http://example.com/sample-manifest/manifest';
+      const canvasId = 'http://example.com/sample-manifest/manifest/canvas/1';
+      const otherCanvasId = 'http://example.com/sample-manifest/manifest/canvas/2';
+
+      test('preserves root element with behavior: \'top\' in structures', () => {
+        const originalStructRoot = manifestWithStructure.structures[0];
+        expect(originalStructRoot.behavior).toBe('top');
+        expect(originalStructRoot.label).toBe(null);
+
+        const structures = iiifParser.parseJSONToStructure(manifestWithStructure, smData);
+        const editedRootRange = structures[0];
+        expect(editedRootRange.behavior).toBe('top');
+        expect(editedRootRange.label).toBe(null);
+      });
+
+      test('updates Range labels for edited structure items', () => {
+        const originalFirstStruct = manifestWithStructure.structures[0].items[0];
+        expect(originalFirstStruct.label).toStrictEqual({ 'en': ['Volleyball for Boys'] });
+        expect(originalFirstStruct.items[0].label).toStrictEqual({ 'en': ['Volleyball for Boys'] });
+
+        const structures = iiifParser.parseJSONToStructure(manifestWithStructure, smData);
+        const editedRootRange = structures[0];
+        expect(editedRootRange.items.length).toBe(2);
+        const firstSection = editedRootRange.items[0];
+        expect(firstSection.label).toStrictEqual({ 'en': ['Volleyball for Boys - First Section'] });
+        expect(firstSection.items[0].label).toStrictEqual({ 'en': ['Volleyball for Boys - Introduction'] });
+      });
+
+      test('preserves Range labels for structure items in other canvases', () => {
+        const structures = iiifParser.parseJSONToStructure(manifestWithStructure, smData);
+        const editedRootRange = structures[0];
+        expect(editedRootRange.items.length).toBe(2);
+
+        const secondSection = editedRootRange.items[1];
+        expect(secondSection.label).toStrictEqual({ 'en': ['Lunchroom Manners'] });
+        expect(secondSection.items[0].label).toStrictEqual({ 'en': ['Introduction'] });
+      });
+
+      test('builds Canvas references for edited span items', () => {
+        const structures = iiifParser.parseJSONToStructure(manifestWithStructure, smData);
+
+        const editedRootRange = structures[0];
+        const firstSection = editedRootRange.items[0];
+        expect(firstSection.items.length).toBe(1);
+        const firstSectionStructure = firstSection.items[0];
+
+        expect(firstSectionStructure.items).toHaveLength(1);
+        expect(firstSectionStructure.items[0].type).toBe('Canvas');
+        expect(firstSectionStructure.items[0].id).toBe(`${canvasId}#t=0,157`);
+      });
+
+      test('preserves Canvas references for for span items in other canvases', () => {
+        const structures = iiifParser.parseJSONToStructure(manifestWithStructure, smData);
+
+        const editedRootRange = structures[0];
+        expect(editedRootRange.items.length).toBe(2);
+
+        const secondSection = editedRootRange.items[1];
+        expect(secondSection.items.length).toBe(2);
+        const secondSectionStructure = secondSection.items[0];
+
+        expect(secondSectionStructure.items).toHaveLength(1);
+        expect(secondSectionStructure.items[0].type).toBe('Canvas');
+        expect(secondSectionStructure.items[0].id).toBe(`${otherCanvasId}#t=0,23`);
+      });
+
+      test('assigns hierarchical Range ids at each level', () => {
+        const structures = iiifParser.parseJSONToStructure(manifestWithStructure, smData);
+
+        const rootRange = structures[0];
+        expect(rootRange.behavior).toBe('top');
+        expect(rootRange.id).toBe(`${manifestId}/range/0`);
+
+        const firstSection = rootRange.items[0];
+        expect(firstSection.id).toBe(`${manifestId}/range/1`);
+        expect(firstSection.items[0].id).toBe(`${manifestId}/range/1-1`);
+
+        const secondSection = rootRange.items[1];
+        expect(secondSection.id).toBe(`${manifestId}/range/2`);
+        expect(secondSection.items[0].id).toBe(`${manifestId}/range/2-1`);
+      });
+
+      test('does not include internal smData properties in structures', () => {
+        const structures = iiifParser.parseJSONToStructure(manifestWithStructure, smData);
+
+        const editedRootRange = structures[0];
+        const firstSection = editedRootRange.items[0];
+        const firstSectionStructureItem = firstSection.items[0];
+
+        [editedRootRange, firstSection, firstSectionStructureItem].forEach(range => {
+          expect(range).not.toHaveProperty('nestedSpan');
+          expect(range).not.toHaveProperty('timeRange');
+          expect(range).not.toHaveProperty('begin');
+          expect(range).not.toHaveProperty('end');
+          expect(range).not.toHaveProperty('valid');
+        });
+      });
+
+      test('all Range ids are unique in structures', () => {
+        const structures = iiifParser.parseJSONToStructure(manifestWithStructure, smData);
+        const allIds = [];
+        const collect = (items) => {
+          for (const item of items ?? []) {
+            if (item.id) allIds.push(item.id);
+            if (Array.isArray(item.items)) collect(item.items);
+          }
+        };
+        collect(structures);
+        expect(new Set(allIds).size).toBe(allIds.length);
+      });
+    });
+
+    describe('parses nested structures and', () => {
+      const manifestId = 'http://example.com/deep-nested/manifest';
+      const canvasId = 'http://example.com/deep-nested/canvas/1';
+
+      // nested smData representing structures in 'manifestWNestedStructure' in testing-helpers.js
+      const nestedSmData = [
+        {
+          type: 'root', label: 'Table of Content - Root', nestedSpan: false, id: '1',
+          items: [
+            {
+              type: 'div', label: 'Level 1 Div - Edited', nestedSpan: false, id: '2',
+              items: [
+                {
+                  type: 'span', label: 'Level 2 Span - Edited', nestedSpan: false, id: '3',
+                  begin: '00:00:00.000', end: '00:01:40.000',
+                  timeRange: { start: 0, end: 100 }, items: []
+                },
+                {
+                  type: 'div', label: 'Level 2 Div', nestedSpan: false, id: '4',
+                  items: [
+                    {
+                      type: 'span', label: 'Level 3 Span', nestedSpan: false, id: '5',
+                      begin: '00:01:40.000', end: '00:03:20.000',
+                      timeRange: { start: 100, end: 200 }, items: []
+                    },
+                    {
+                      type: 'div', label: 'Level 3 Div', nestedSpan: false, id: '6',
+                      items: [
+                        {
+                          type: 'span', label: 'Level 4 Span', nestedSpan: false, id: '7',
+                          begin: '00:03:20.000', end: '00:05:00.000',
+                          timeRange: { start: 200, end: 300 }, items: [
+
+                            {
+                              type: 'span', label: 'Level 5 Span', nestedSpan: false, id: '8',
+                              begin: '00:04:10.000', end: '00:04:35.000',
+                              timeRange: { start: 250, end: 275 }, items: []
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ];
+
+      test('updates nested Range labels', () => {
+        const structures = iiifParser.parseJSONToStructure(manifestWNestedStructure, nestedSmData);
+
+        expect(structures).toHaveLength(1);
+        const rootRange = structures[0];
+        expect(rootRange.type).toBe('Range');
+        expect(rootRange.label).toStrictEqual({ en: ['Table of Content - Root'] });
+
+        const level_1 = rootRange.items[0];
+        expect(level_1.type).toBe('Range');
+        expect(level_1.label).toStrictEqual({ en: ['Level 1 Div - Edited'] });
+        expect(level_1.items).toHaveLength(2);
+
+        expect(level_1.items[0].label).toStrictEqual({ en: ['Level 2 Span - Edited'] });
+        expect(level_1.items[1].label).toStrictEqual({ en: ['Level 2 Div'] });
+      });
+
+      test('builds Canvas references for nested span items', () => {
+        const structures = iiifParser.parseJSONToStructure(manifestWNestedStructure, nestedSmData);
+
+        const rootRange = structures[0];
+        const level_1 = rootRange.items[0];
+
+        // Level 2 span
+        const level_2_span = level_1.items[0];
+        expect(level_2_span.items).toHaveLength(1);
+        expect(level_2_span.items[0].type).toBe('Canvas');
+        expect(level_2_span.items[0].id).toBe(`${canvasId}#t=0,100`);
+
+        // Level 2 div
+        const level_2_div = level_1.items[1];
+        const level_3_span = level_2_div.items[0];
+        expect(level_3_span.items).toHaveLength(1);
+        expect(level_3_span.items[0].type).toBe('Canvas');
+        expect(level_3_span.items[0].id).toBe(`${canvasId}#t=100,200`);
+      });
+
+      test('assigns hierarchical Range ids at each level', () => {
+        const structures = iiifParser.parseJSONToStructure(manifestWNestedStructure, nestedSmData);
+
+        const rootRange = structures[0];
+        expect(rootRange.id).toBe(`${manifestId}/range/1`);
+
+        const level_1 = rootRange.items[0];
+        expect(level_1.id).toBe(`${manifestId}/range/1-1`);
+        // Level 2 span 
+        expect(level_1.items[0].id).toBe(`${manifestId}/range/1-1-1`);
+
+        const level_2_div = level_1.items[1];
+        expect(level_2_div.id).toBe(`${manifestId}/range/1-1-2`);
+        // Level 3 span 
+        expect(level_2_div.items[0].id).toBe(`${manifestId}/range/1-1-2-1`);
+      });
+
+      test('does not include internal smData properties in structures', () => {
+        const structures = iiifParser.parseJSONToStructure(manifestWNestedStructure, nestedSmData);
+
+        const rootRange = structures[0];
+        const level_1 = rootRange.items[0];
+        const level_2_span = level_1.items[0];
+
+        [rootRange, level_1, level_2_span].forEach(range => {
+          expect(range).not.toHaveProperty('nestedSpan');
+          expect(range).not.toHaveProperty('timeRange');
+          expect(range).not.toHaveProperty('begin');
+          expect(range).not.toHaveProperty('end');
+          expect(range).not.toHaveProperty('valid');
+        });
+      });
+
+      test('all Range ids are unique across deeply nested output', () => {
+        const structures = iiifParser.parseJSONToStructure(manifestWNestedStructure, nestedSmData);
+        const allIds = [];
+        const collect = (items) => {
+          for (const item of items ?? []) {
+            if (item.id) allIds.push(item.id);
+            if (Array.isArray(item.items)) collect(item.items);
+          }
+        };
+        collect(structures);
+        expect(new Set(allIds).size).toBe(allIds.length);
+      });
     });
   });
 

--- a/src/services/iiif-parser.js
+++ b/src/services/iiif-parser.js
@@ -1,4 +1,5 @@
 import { parseManifest } from "manifesto.js";
+import { v4 as uuidv4 } from 'uuid';
 import StructuralMetadataUtils from "./StructuralMetadataUtils";
 import { getMimetype, readAnnotations } from "./utils";
 
@@ -131,17 +132,21 @@ export function parseStructureToJSON(manifest, duration, canvasIndex = 0) {
 
   if (!manifest) return [];
   let buildStructureItems = (items, children, parent = null) => {
-    if (items.length > 0) {
+    if (items?.length > 0) {
       items.map((i) => {
         const range = parseManifest(manifest)
           .getRangeById(i.id);
+        // Mark a Canvas/section item as a 'div' with a Canvas reference
+        let isCanvasSection = false;
+        if (i.items?.length > 0 && i.items[0].type === 'Canvas') isCanvasSection = true;
         if (range) {
           // Set default type to 'div' and change it as needed for timespans
           let structItem = {
             label: getLabelValue(i.label),
             items: [],
             type: "div",
-            nestedSpan: false
+            nestedSpan: false,
+            isCanvasSection,
           };
 
           // Get canvases associated with the current Range
@@ -183,38 +188,58 @@ export function parseStructureToJSON(manifest, duration, canvasIndex = 0) {
 
   if (manifest != undefined && manifest != null) {
     structures = manifest.structures != undefined ? manifest.structures : [];
-    // Ignore the top element, this gets injected in the manifest generation in Avalon.
-    // `iiif_manifest` gem keeps wrapping the structure with a root element with 
-    // behavior set to 'top' without a label every time structure
-    // is saved in SME.
-    const behavior = structures.length > 0 ? structures[0]?.behavior : '';
-    structures = behavior === 'top' ? structures[0].items : structures;
     manifestName = getLabelValue(manifest.label);
   }
 
-  // Check for empty structures in manifest
-  if (structures.length > 0) {
-    const root = structures[canvasIndex];
+  const behavior = structures.length > 0 ? structures[0]?.behavior : '';
+  const canvasCount = parseManifest(manifest).getSequences()[0].getCanvases().length;
+
+  let root;
+  if (behavior === 'top') {
+    /**
+     * Ignore the top element, this gets injected in the manifest generation in Avalon.
+     * `iiif_manifest` gem keeps wrapping the structure with a root element with
+     * behavior set to 'top' without a label every time structure
+     * is saved in SME.
+     */
+    const structureItems = structures[0].items;
+    root = structureItems?.length > 0 ? structureItems[canvasIndex] : [];
+  } else if (structures.length > 0 && structures.length != canvasCount) {
+    /**
+     * When the root doesn't have behavior='top' then look into the structures array
+     * and check if the root level has structures for each Canvas/section in the Manifest.
+     * E.g. https://iiif.io/api/cookbook/recipe/0065-opera-multiple-canvases/
+     */
+    const structureSections = structures[0].items;
+    root = structureSections.length === canvasCount ? structureSections[canvasIndex] : structures;
+  } else {
+    root = structures[canvasIndex];
+  }
+
+  if (root) {
     let children = [];
+    let isCanvasSection = false;
+
+    // Mark the root is a Canvas/section item -> a 'div' with a Canvas reference
+    if (root.items?.length > 0 && root.items[0]?.type === 'Canvas') {
+      isCanvasSection = true;
+    }
 
     // Build the nested JSON object from structure
     buildStructureItems(root.items, children, { type: 'div' });
 
     // Add the root element to the JSON object
     structureJSON.push({
-      type: 'div',
+      type: 'div', items: children, nestedSpan: false,
       label: getLabelValue(root.label),
-      items: children,
-      nestedSpan: false
+      isCanvasSection,
     });
   }
   // Create an empty structure with manifest information
   else if (manifestName != undefined) {
     structureJSON.push({
-      label: manifestName,
-      items: [],
-      type: 'div',
-      nestedSpan: false
+      label: manifestName, items: [], type: 'div', nestedSpan: false,
+      isCanvasSection: true
     });
   }
   const structureWithIDs = smUtils.addUUIds(structureJSON);
@@ -272,4 +297,123 @@ export function getLabelValue(label) {
     return decodeHTML(label);
   }
   return 'Label could not be parsed';
+}
+
+/**
+ * Convert the internal 'smData' structure back to a IIIF Presentation API 3.0
+ * 'structures' array of Range objects. This is the inverse of 'parseStructureToJSON'
+ * @param {Array} smData - internal structure tree from state
+ * @param {Object} manifest - raw IIIF manifest object
+ * @param {Number} canvasIndex - index of the current Canvas(defaults to 0)
+ * @returns {Array} IIIF 'structures' array
+ */
+export function parseJSONToStructure(manifest, smData, canvasIndex = 0) {
+  if (!smData || smData?.length === 0) {
+    if (!manifest) return [];
+    else return manifest.structures;
+  }
+
+  const smu = new StructuralMetadataUtils();
+  let canvasId, manifestId, structureBehavior, structures;
+  let structureItems = [];
+  // 'structures' property has a root Range surrounding sections
+  let hasWrapperRange = false;
+
+  if (manifest != undefined && manifest != null) {
+    // Get the canvasId to build the Canvas reference for Range items as needed
+    canvasId = manifest.items?.[canvasIndex]?.id ?? manifest.items?.[0]?.id;
+    if (!canvasId) return [];
+
+    // Number of items under the Manifest's 'items' property
+    const canvasCount = parseManifest(manifest).getSequences()[0]
+      .getCanvases().length;
+
+    structures = manifest.structures != undefined ? manifest.structures : [];
+    // Remove the '.json' suffix in the Manifest label
+    manifestId = manifest.id.replace(/\.json$/, "");
+
+    structureBehavior = structures.length > 0 ? structures[0]?.behavior : '';
+    if (structureBehavior === 'top') {
+      /**
+       * When there is a root Range with behavior='top' avoid it and retrieve the
+       * relevant structure item for the current Canvas from its 'items'.
+       * Update the top Range's id to match the new hierarchical format starting with 0.
+       * E.g. Avalon manifests -> https://media.dlib.indiana.edu/media_objects/qn59qp839/
+       */
+      structures[0].id = `${manifestId}/range/0`;
+      structureItems = structures[0].items;
+      hasWrapperRange = true;
+    } else if (structures.length > 0 && structures.length != canvasCount) {
+      /**
+       * When the root doesn't have behavior='top' then look into the structures array
+       * and check if the root level has structures for each Canvas/section in the Manifest.
+       * E.g. https://iiif.io/api/cookbook/recipe/0065-opera-multiple-canvases/
+       */
+      const structureSections = structures[0].items;
+      if (structureSections.length === canvasCount) {
+        structures[0].id = `${manifestId}/range/0`;
+      }
+      structureItems = structureSections.length === canvasCount ? structureSections : structures;
+      hasWrapperRange = true;
+    } else {
+      structureItems = structures;
+    }
+  }
+
+  const buildRange = (item, pathKey) => {
+    const range = {
+      id: `${manifestId}/range/${pathKey}`,
+      type: 'Range',
+      label: { en: [item.label] },
+      items: [],
+    };
+
+    if (item.isCanvasSection) {
+      const canvasDuration = manifest.items?.[canvasIndex]?.duration ?? 0;
+      range.items.push({ id: `${canvasId}#t=0,${canvasDuration}`, type: 'Canvas' });
+    } else if (item.type === 'span') {
+      const start = smu.convertToSeconds(item.begin);
+      const end = smu.convertToSeconds(item.end);
+      range.items.push({ id: `${canvasId}#t=${start},${end}`, type: 'Canvas' });
+    }
+
+    (item.items || []).forEach((child, i) => {
+      range.items.push(buildRange(child, `${pathKey}-${i + 1}`));
+    });
+
+    return range;
+  };
+  const buildIds = (item, pathKey) => {
+    item.id = `${manifestId}/range/${pathKey}`;
+
+    (item.items || []).forEach((child, i) => {
+      if (child.type === 'Range') buildIds(child, `${pathKey}-${i + 1}`);
+    });
+
+    return item;
+  };
+
+  if (structureItems.length > 0) {
+    let updatedRanges = [];
+    // Build the updated Range items from the internal structure tree
+    const changedRange = buildRange(smData[0], `${canvasIndex + 1}`);
+    // Update the Range ids for the rest of the structure items for multi-Canvas Manifest
+    for (let i = 0; i < structureItems.length; i++) {
+      if (i === canvasIndex) {
+        // Use the updated Range for the edited Canvas
+        updatedRanges.push(changedRange);
+        continue;
+      } else {
+        // Update the Range ids for the rest
+        const updated = buildIds(JSON.parse(JSON.stringify(structureItems[i])), i + 1);
+        updatedRanges.push(updated);
+      }
+    }
+
+    if (hasWrapperRange) {
+      return [{ ...structures[0], items: updatedRanges }];
+    } else {
+      return updatedRanges;
+    }
+  }
 }

--- a/src/services/testing-helpers.js
+++ b/src/services/testing-helpers.js
@@ -683,7 +683,7 @@ export const manifestWithStructure = {
         {
           type: 'Range',
           id: 'http://example.com/sample-manifest/manifest/range/1',
-          label: 'Volleyball for Boys',
+          label: { en: ['Volleyball for Boys'] },
           items: [
             {
               type: 'Range',
@@ -1012,52 +1012,94 @@ export const manifestWEmptyRanges = {
   ]
 };
 
-// Manifest with a Range that has no items
-export const manifestWoStructItems = {
+// Manifest with Canvas attached to section-level structures (Avalon)
+export const manifestWithSectionCanvas = {
   '@context': ['http://iiif.io/api/presentation/3/context.json'],
   type: 'Manifest',
-  id: 'http://example.com/undefined-items/manifest',
-  label: { en: ['Range with undefined items'] },
+  id: 'http://example.com/canvas-ranges/manifest',
+  label: { en: ['Canvas Range Sections'] },
   items: [
     {
       type: 'Canvas',
-      id: 'http://example.com/undefined-items/canvas/1',
+      id: 'http://example.com/canvas-ranges/canvas/1',
       width: 1920,
       height: 1080,
-      duration: 662.037,
+      duration: 500,
       items: [
         {
           type: 'AnnotationPage',
-          id: 'http://example.com/undefined-items/canvas/1/page',
+          id: 'http://example.com/canvas-ranges/canvas/1/page',
           items: [
             {
               type: 'Annotation',
               motivation: 'painting',
               body: {
-                id: 'http://example.com/undefined-items/media.mp4',
+                id: 'http://example.com/canvas-ranges/media.mp4',
                 type: 'Video',
                 format: 'video/mp4',
-                duration: 662.037,
-                height: 1080,
-                width: 1920,
+                duration: 500
               },
-              target: 'http://example.com/undefined-items/canvas/1'
+              target: 'http://example.com/canvas-ranges/canvas/1'
+            }
+          ],
+          label: { none: ["Media"] }
+        }
+      ]
+    },
+    {
+      type: 'Canvas',
+      id: 'http://example.com/canvas-ranges/canvas/2',
+      width: 1920,
+      height: 1080,
+      duration: 660,
+      items: [
+        {
+          type: 'AnnotationPage',
+          id: 'http://example.com/canvas-ranges/canvas/2/page',
+          items: [
+            {
+              type: 'Annotation',
+              motivation: 'painting',
+              body: {
+                id: 'http://example.com/canvas-ranges/media_2.mp4',
+                type: 'Video',
+                format: 'video/mp4',
+                duration: 660
+              },
+              target: 'http://example.com/canvas-ranges/canvas/2'
             }
           ]
         }
-      ]
+      ],
+      label: { none: ["Media 2"] }
     }
   ],
   structures: [
     {
       type: 'Range',
-      id: 'http://example.com/undefined-items/range/root',
+      id: 'http://example.com/canvas-ranges/range/0',
       label: { en: ['Root'] },
       items: [
         {
           type: 'Range',
-          id: 'http://example.com/undefined-items/range/valid',
-          label: { en: ['Valid Range'] },
+          id: 'http://example.com/canvas-ranges/range/1',
+          label: { en: ['Media'] },
+          items: [
+            {
+              type: 'Canvas',
+              id: 'http://example.com/canvas-ranges/canvas/1#t=0,500'
+            }
+          ]
+        },
+        {
+          type: 'Range',
+          id: 'http://example.com/canvas-ranges/range/2',
+          label: { en: ['Media 2'] },
+          items: [
+            {
+              type: 'Canvas',
+              id: 'http://example.com/canvas-ranges/canvas/2#t=0,660'
+            }]
         }
       ]
     }


### PR DESCRIPTION
Related issue: https://github.com/avalonmediasystem/avalon/issues/5033

With the sample Manifest in repo:
<img width="1044" height="865" alt="Screenshot 2026-03-19 at 4 07 57 PM" src="https://github.com/user-attachments/assets/1c379363-c405-4eb2-880e-a2e6b380fb35" />

Cookbook Manifest without a waveform, allows to edit the structure with a message about the waveform. The nested child timespan in the image is a newly created timespan.
<img width="882" height="656" alt="Screenshot 2026-03-19 at 4 13 36 PM" src="https://github.com/user-attachments/assets/0824a9c4-f663-4f27-80f0-c109603a1112" />
